### PR TITLE
begin nomad-governance track

### DIFF
--- a/instruqt-tracks/nomad-governance/config.yml
+++ b/instruqt-tracks/nomad-governance/config.yml
@@ -1,0 +1,26 @@
+version: "2"
+virtualmachines:
+- name: nomad-server-1
+  image: instruqt-hashicorp/nomad-ent-0-10-4
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-server-1:8500
+  machine_type: n1-standard-1
+- name: nomad-client-1
+  image: instruqt-hashicorp/nomad-ent-0-10-4
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-client-1:8500
+  machine_type: n1-standard-1
+- name: nomad-client-2
+  image: instruqt-hashicorp/nomad-ent-0-10-4
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-client-2:8500
+  machine_type: n1-standard-1
+- name: nomad-client-3
+  image: instruqt-hashicorp/nomad-ent-0-10-4
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-client-3:8500
+  machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-governance/track.yml
+++ b/instruqt-tracks/nomad-governance/track.yml
@@ -1,0 +1,89 @@
+slug: nomad-governance
+id: 05ovf6ut5ojh
+type: track
+title: Nomad Enterprise Governance
+teaser: Learn how to use Nomad Enterprise's governance capabilities including namespaces,
+  resource quotas, and Sentinel policies.
+description: |-
+  This track will show you how to use Nomad Enterprise's governance capabilities including namespaces, resource quotas, and Sentinel policies.
+
+  Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics) and [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster) tracks.
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
+tags:
+- nomad
+- governance
+- namespace
+- resource quotas
+- Sentinel
+owner: hashicorp
+developers:
+- roger@hashicorp.com
+private: true
+published: true
+challenges:
+- slug: verify-nomad-cluster-health
+  id: ktmjptuistsh
+  type: challenge
+  title: Verify the Health of Your Nomad Enterprise Cluster
+  teaser: |
+    Verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts.
+  assignment: |-
+    In this challenge, you will verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
+
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients.
+
+    First, verify that all 4 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
+    ```
+    consul members
+    ```
+    You should see 4 Consul agents.
+
+    Check that the Nomad server is running by running this command on the "Server" tab:
+    ```
+    nomad server members
+    ```
+    You should see 1 Nomad server.
+
+    Check the status of the Nomad client nodes by running this command on the "Server" tab:
+    ```
+    nomad node status
+    ```
+    You should see 3 Nomad clients.
+
+    Please also run the last command on the "Client 1", "Client 2", and "Client 3" tabs. In each case, you should see the same 3 Nomad clients.
+
+    In the next challenge, you will configure Nomad Enterprise namespaces.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts.
+
+      This will include checking the health of a Consul cluster that has been set up on the same VMs.
+  tabs:
+  - title: Config Files
+    type: code
+    hostname: nomad-server-1
+    path: /root/nomad/
+  - title: Server
+    type: terminal
+    hostname: nomad-server-1
+  - title: Client 1
+    type: terminal
+    hostname: nomad-client-1
+  - title: Client 2
+    type: terminal
+    hostname: nomad-client-2
+  - title: Client 3
+    type: terminal
+    hostname: nomad-client-3
+  - title: Nomad UI
+    type: service
+    hostname: nomad-server-1
+    port: 4646
+  - title: Consul UI
+    type: service
+    hostname: nomad-server-1
+    port: 8500
+  difficulty: basic
+  timelimit: 3600
+checksum: "678055617374999598"

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-1
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+set -e
+
+grep -q "nomad node status" /root/.bash_history || fail-message "You haven't run 'nomad node status' on Client 1 yet."
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-2
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+set -e
+
+grep -q "nomad node status" /root/.bash_history || fail-message "You haven't run 'nomad node status' on Client 2 yet."
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-3
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+set -e
+
+grep -q "nomad node status" /root/.bash_history || fail-message "You haven't run 'nomad node status' on Client 3 yet."
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-server-1
@@ -1,0 +1,29 @@
+#!/bin/bash -l
+
+set -e
+
+grep -q "consul members" /root/.bash_history || fail-message "You haven't run 'consul members' on the Server yet."
+
+grep -q "nomad server members" /root/.bash_history || fail-message "You haven't run 'nomad server members' on the Server yet."
+
+grep -q "nomad node status" /root/.bash_history || fail-message "You haven't run 'nomad node status' on the Server yet."
+
+consul_clients=$(consul members | grep alive | wc -l)
+if [ $consul_clients -ne 4 ]; then
+  echo "There are not 4 running Consul clients."
+  exit 1
+fi
+
+nomad_servers=$(nomad server members | grep alive | wc -l)
+if [ $nomad_servers -ne 1 ]; then
+  echo "The Nomad servers is not running."
+  exit 1
+fi
+
+nomad_clients=$(nomad node status | grep ready | wc -l)
+if [ $nomad_clients -ne 3 ]; then
+  echo "There are not 3 running Nomad clients."
+  exit 1
+fi
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-1
@@ -1,0 +1,46 @@
+#!/bin/bash -l
+
+# Write Nomad Client 1 Config
+cat <<-EOF > /etc/nomad.d/nomad-client1.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client1"
+
+# Give the agent a unique name.
+name = "client1"
+
+# Enable the client
+client {
+  enabled = true
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-1:8500"
+}
+EOF
+
+# Write Consul Client 1 Config
+cat <<-EOF > /etc/consul.d/consul-client1.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client1",
+  "node_name": "client1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  }
+}
+EOF
+
+systemctl start consul
+
+sleep 15
+
+systemctl start nomad
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-2
@@ -1,0 +1,46 @@
+#!/bin/bash -l
+
+# Write Nomad Client 2 Config
+cat <<-EOF > /etc/nomad.d/nomad-client2.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client2"
+
+# Give the agent a unique name
+name = "client2"
+
+# Enable the client
+client {
+  enabled = true
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-2:8500"
+}
+EOF
+
+# Write Consul Client 2 Config
+cat <<-EOF > /etc/consul.d/consul-client2.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client2",
+  "node_name": "client2",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  }
+}
+EOF
+
+systemctl start consul
+
+sleep 15
+
+systemctl start nomad
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-3
@@ -1,0 +1,46 @@
+#!/bin/bash -l
+
+# Write Nomad Client 3 Config
+cat <<-EOF > /etc/nomad.d/nomad-client3.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client3"
+
+# Give the agent a unique name
+name = "client3"
+
+# Enable the client
+client {
+  enabled = true
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-3:8500"
+}
+EOF
+
+# Write Consul Client 3 Config
+cat <<-EOF > /etc/consul.d/consul-client3.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client3",
+  "node_name": "client3",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  }
+}
+EOF
+
+systemctl start consul
+
+sleep 15
+
+systemctl start nomad
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-server-1
@@ -1,0 +1,198 @@
+#!/bin/bash -l
+
+mkdir /root/nomad
+
+# Write Nomad Server 1 Config
+cat <<-EOF > /etc/nomad.d/nomad-server1.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/server1"
+
+# Give the agent a unique name.
+name = "server1"
+
+# Enable the server
+server {
+  enabled = true
+  bootstrap_expect = 1
+}
+
+# Consul configuration
+consul {
+  address = "nomad-server-1:8500"
+}
+EOF
+
+# Write Copy of Nomad Server 1 Config
+cat <<-EOF > /root/nomad/nomad-server1.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/server1"
+
+# Give the agent a unique name.
+name = "server1"
+
+# Enable the server
+server {
+  enabled = true
+  bootstrap_expect = 1
+}
+
+# Consul configuration
+consul {
+  address = "nomad-server-1:8500"
+}
+EOF
+
+# Write Consul Server 1 Config
+cat <<-EOF > /etc/consul.d/consul-server1.json
+{
+  "server": true,
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/server1",
+  "node_name": "server1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "bootstrap_expect": 1,
+  "connect": {
+    "enabled": true
+  }
+}
+EOF
+
+# Write Copy of Consul Server 1 Config
+cat <<-EOF > /root/nomad/consul-server1.json
+{
+  "server": true,
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/server1",
+  "node_name": "server1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "bootstrap_expect": 1,
+  "connect": {
+    "enabled": true
+  }
+}
+EOF
+
+# Write Nomad Client 1 Config
+cat <<-EOF > /root/nomad/nomad-client1.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client1"
+
+# Give the agent a unique name.
+name = "client1"
+
+# Enable the client
+client {
+  enabled = true
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-1:8500"
+}
+EOF
+
+# Write Consul Client 1 Config
+cat <<-EOF > /root/nomad/consul-client1.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client1",
+  "node_name": "client1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  }
+}
+EOF
+
+# Write Nomad Client 2 Config
+cat <<-EOF > /root/nomad/nomad-client2.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client2"
+
+# Give the agent a unique name.
+name = "client2"
+
+# Enable the client
+client {
+  enabled = true
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-2:8500"
+}
+EOF
+
+# Write Consul Client 2 Config
+cat <<-EOF > /root/nomad/consul-client2.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client2",
+  "node_name": "client2",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  }
+}
+EOF
+
+# Write Nomad Client 3 Config
+cat <<-EOF > /root/nomad/nomad-client3.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client3"
+
+# Give the agent a unique name.
+name = "client3"
+
+# Enable the client
+client {
+  enabled = true
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-3:8500"
+}
+EOF
+
+# Write Consul Client 3 Config
+cat <<-EOF > /root/nomad/consul-client3.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client3",
+  "node_name": "client3",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  }
+}
+EOF
+
+systemctl start consul
+
+sleep 15
+
+systemctl start nomad
+
+sleep 30
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-1
@@ -1,0 +1,10 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+# Run nomad node status
+nomad node status
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-2
@@ -1,0 +1,10 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+# Run nomad node status
+nomad node status
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-3
@@ -1,0 +1,10 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+# Run nomad node status
+nomad node status
+
+exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-server-1
@@ -1,0 +1,16 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+# Run consul members
+consul members
+
+# Run nomad server members
+nomad server members
+
+# Run nomad node status
+nomad node status
+
+exit 0


### PR DESCRIPTION
begin a Nomad Governance Instruqt track that can also be used as a template for other tracks that need Nomad Enterprise.

It creates a single Nomad/Consul server and 3 Nomad/Consul clients, running Nomad Enterprise 0.10.4 and Consul OSS 1.7.0.

The GCP image used is instruqt-hashicorp/nomad-ent-0-10-4