### PR TITLE
Add update strategies track

### DIFF
--- a/instruqt-tracks/nomad-update-strategies/blue-green-deployment/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/blue-green-deployment/check-nomad-server-1
@@ -1,0 +1,8 @@
+#!/bin/bash -l
+
+set -e
+
+#
+grep -q "" /root/.bash_history || fail-message "You haven't on the Nomad server yet."
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/blue-green-deployment/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/blue-green-deployment/check-nomad-server-1
@@ -2,7 +2,18 @@
 
 set -e
 
-#
-grep -q "" /root/.bash_history || fail-message "You haven't on the Nomad server yet."
+grep -q "cd /root/nomad/jobs" /root/.bash_history || fail-message "You have not navigated to /root/nomad/jobs on the Nomad server yet."
+
+grep -q "  canary = 3" /root/nomad/jobs/chat-app.nomad || fail-message "You have not uncommented 'canary = 3' in  chat-app.nomad on the Nomad server yet."
+
+grep -q "anon-app:0.02" /root/nomad/jobs/chat-app.nomad || fail-message "You have not set the image tag to '0.02' in  chat-app.nomad on the Nomad server yet."
+
+grep -q "nomad job plan chat-app.nomad" /root/.bash_history || fail-message "You have not planned the blue/green deployment of the chat-app job on the Nomad server yet."
+
+grep -q "nomad job run chat-app.nomad" /root/.bash_history || fail-message "You have not run the blue/green deployment of the chat-app job on the Nomad server yet."
+
+grep -q "nomad job status chat-app" /root/.bash_history || fail-message "You have not checked the status of the chat-app job on the Nomad server yet."
+
+grep -q "nomad deployment promote" /root/.bash_history || fail-message "You have not promoted the blue/green deployment of the chat-app job on the Nomad server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/blue-green-deployment/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/blue-green-deployment/setup-nomad-server-1
@@ -1,0 +1,8 @@
+#!/bin/bash -l
+
+set -e
+
+rm /root/.bash_history
+touch /root/.bash_history
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/blue-green-deployment/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/blue-green-deployment/solve-nomad-server-1
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=~/.bash_history
+set -o history
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/blue-green-deployment/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/blue-green-deployment/solve-nomad-server-1
@@ -4,4 +4,29 @@
 HISTFILE=~/.bash_history
 set -o history
 
+# Change directory
+cd /root/nomad/jobs
+
+# Edit the chat-nomad.nomad Job
+sed -i "s/# canary = 3/canary = 3/g" chat-app.nomad
+sed -i "s/dark-0.02/0.02/g" chat-app.nomad
+
+# Plan a blue/green deployment of the chat-app job
+nomad job plan chat-app.nomad
+
+# Run a blue/green deployment of the chat-app job
+nomad job run chat-app.nomad
+
+# Sleep
+sleep 180
+
+# Check the status of the blue/green deployment
+nomad job status chat-app > blue-green-status.txt
+
+# Determine the ID of the active deployment
+blue_green_deployment_id=$(cat blue-green-status.txt | grep "Latest Deployment" -A1 | grep ID | cut -d'=' -f2 | cut -d' ' -f2)
+
+# Promote the deployment
+nomad deployment promote $blue_green_deployment_id
+
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/canary-deployment/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/canary-deployment/check-nomad-server-1
@@ -2,7 +2,18 @@
 
 set -e
 
-#
-grep -q "" /root/.bash_history || fail-message "You haven't on the Nomad server yet."
+grep -q "cd /root/nomad/jobs" /root/.bash_history || fail-message "You have not navigated to /root/nomad/jobs on the Nomad server yet."
+
+grep -q "canary = 1" /root/nomad/jobs/chat-app.nomad || fail-message "You have not set canary to 1 in chat-app.nomad on the Nomad server yet."
+
+grep -q "dark-0.02" /root/nomad/jobs/chat-app.nomad || fail-message "You have not set the image tag to 'dark-0.02' in  chat-app.nomad on the Nomad server yet."
+
+grep -q "nomad job plan chat-app.nomad" /root/.bash_history || fail-message "You have not planned the canary deployment of the chat-app job on the Nomad server yet."
+
+grep -q "nomad job run chat-app.nomad" /root/.bash_history || fail-message "You have not run the canary deployment of the chat-app job on the Nomad server yet."
+
+grep -q "nomad job status chat-app" /root/.bash_history || fail-message "You have not checked the status of the canary deployment of the chat-app job on the Nomad server yet."
+
+grep -q "nomad deployment fail" /root/.bash_history || fail-message "You have not failed the canary deployment of the chat-app job on the Nomad server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/canary-deployment/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/canary-deployment/check-nomad-server-1
@@ -1,0 +1,8 @@
+#!/bin/bash -l
+
+set -e
+
+#
+grep -q "" /root/.bash_history || fail-message "You haven't on the Nomad server yet."
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/canary-deployment/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/canary-deployment/setup-nomad-server-1
@@ -1,0 +1,8 @@
+#!/bin/bash -l
+
+set -e
+
+rm /root/.bash_history
+touch /root/.bash_history
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/canary-deployment/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/canary-deployment/solve-nomad-server-1
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=~/.bash_history
+set -o history
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/canary-deployment/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/canary-deployment/solve-nomad-server-1
@@ -4,4 +4,29 @@
 HISTFILE=~/.bash_history
 set -o history
 
+# Change directory
+cd /root/nomad/jobs
+
+# Edit chat-app.nomad
+sed -i "s/canary = 3/canary = 1/g" chat-app.nomad
+sed -i "s/0.02/dark-0.02/g" chat-app.nomad
+
+# Plan the job
+nomad job plan chat-app.nomad
+
+# Run the job
+nomad job run chat-app.nomad
+
+# Sleep
+sleep 120
+
+# Check the status
+nomad job status chat-app > canary-status.txt
+
+# Determine the ID of the active deployment
+canary_deployment_id=$(cat canary-status.txt | grep "Latest Deployment" -A1 | grep ID | cut -d'=' -f2 | cut -d' ' -f2)
+
+# Roll back the deployment
+nomad deployment fail $canary_deployment_id
+
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/config.yml
+++ b/instruqt-tracks/nomad-update-strategies/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-5-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-5-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-5-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-5-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-3:8500

--- a/instruqt-tracks/nomad-update-strategies/config.yml
+++ b/instruqt-tracks/nomad-update-strategies/config.yml
@@ -1,0 +1,26 @@
+version: "2"
+virtualmachines:
+- name: nomad-server-1
+  image: instruqt-hashicorp/hashistack-0-4-0
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-server-1:8500
+  machine_type: n1-standard-1
+- name: nomad-client-1
+  image: instruqt-hashicorp/hashistack-0-4-0
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-client-1:8500
+  machine_type: n1-standard-1
+- name: nomad-client-2
+  image: instruqt-hashicorp/hashistack-0-4-0
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-client-2:8500
+  machine_type: n1-standard-1
+- name: nomad-client-3
+  image: instruqt-hashicorp/hashistack-0-4-0
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-client-3:8500
+  machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/check-nomad-server-1
@@ -1,0 +1,8 @@
+#!/bin/bash -l
+
+set -e
+
+#
+grep -q "" /root/.bash_history || fail-message "You haven't on the Nomad server yet."
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/check-nomad-server-1
@@ -3,6 +3,16 @@
 set -e
 
 #
-grep -q "" /root/.bash_history || fail-message "You haven't on the Nomad server yet."
+grep -q "cd /root/nomad/jobs" /root/.bash_history || fail-message "You have not navigated to /root/nomad/jobs on the Nomad server yet."
+
+grep -q "nomad job run mongodb.nomad" /root/.bash_history || fail-message "You have not run the mongodb.nomad job on the Nomad server yet."
+
+grep -q "nomad job status mongodb" /root/.bash_history || fail-message "You have not checked the status of the mongodb job with the CLI on the Nomad server yet."
+
+grep -q "nomad job run fabio.nomad" /root/.bash_history || fail-message "You have not run the fabio.nomad job on the Nomad server yet."
+
+grep -q "nomad job run chat-app.nomad" /root/.bash_history || fail-message "You have not run the chat-app.nomad job on the Nomad server yet."
+
+grep -q "nomad job status chat-app" /root/.bash_history || fail-message "You have not checked the status of the chat-app job on the Nomad server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/setup-nomad-server-1
@@ -71,8 +71,8 @@ job "fabio" {
       }
 
       resources {
-        cpu    = 100
-        memory = 64
+        cpu    = 200
+        memory = 128
         network {
           mbits = 20
           port "lb" {
@@ -89,7 +89,7 @@ job "fabio" {
 EOF
 
 # Write the chatapp.nomad job
-cat <<-EOF > /root/nomad/jobs/chatapp.nomad
+cat <<-EOF > /root/nomad/jobs/chat-app.nomad
 job "chat-app" {
   datacenters = ["dc1"]
   type = "service"
@@ -97,18 +97,22 @@ job "chat-app" {
   group "chat-app" {
     count = 3
 
+    spread {
+      attribute = "\${node.unique.name}"
+    }
+
     update {
-      max_parallel     = 1
-      health_check     = "task_states"
+      max_parallel = 1
+      health_check = "checks"
       min_healthy_time = "15s"
       healthy_deadline = "2m"
+      # canary = 3
     }
 
     network {
       mode = "bridge"
       port "http" {
-        static = 9002
-        to     = 5000
+        to = 5000
       }
     }
 
@@ -125,7 +129,7 @@ job "chat-app" {
       }
 
       resources {
-        cpu = 500 # MHz
+        cpu = 300 # MHz
         memory = 512 # MB
       }
 
@@ -133,8 +137,15 @@ job "chat-app" {
 
     service {
       name = "chat-app"
-      tags = ["chat-app"]
+      tags = ["urlprefix-/","chat-app"]
       port = "http"
+      check {
+        name     = "chat-app alive"
+        type     = "http"
+        path     = "/chats"
+        interval = "10s"
+        timeout  = "2s"
+      }
 
       connect {
         sidecar_service {

--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/setup-nomad-server-1
@@ -1,0 +1,157 @@
+#!/bin/bash -l
+
+set -e
+
+mkdir /root/nomad/jobs
+
+# Write the mongodb.nomad job
+cat <<-EOF > /root/nomad/jobs/mongodb.nomad
+job "mongodb" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "db" {
+    count = 1
+
+    volume "mongodb_vol" {
+      type = "host"
+      source = "mongodb_mount"
+    }
+
+    network {
+      mode = "bridge"
+    }
+
+    task "mongodb" {
+      driver = "docker"
+
+      config {
+        image = "mongo"
+      }
+
+      volume_mount {
+        volume = "mongodb_vol"
+        destination = "/data/db"
+      }
+
+      resources {
+        cpu = 500 # MHz
+        memory = 512 # MB
+      }
+
+    } # end mongodb task
+
+    service {
+      name = "mongodb"
+      tags = ["mongodb"]
+      port = "27017"
+
+      connect {
+        sidecar_service {}
+      }
+    } # end service
+
+  } # end db group
+
+}
+EOF
+
+# Write fabio.nomad
+cat <<-EOF > /root/nomad/jobs/fabio.nomad
+job "fabio" {
+  datacenters = ["dc1"]
+  type = "system"
+
+  group "fabio" {
+    task "fabio" {
+      driver = "docker"
+      config {
+        image = "fabiolb/fabio"
+        network_mode = "host"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 64
+        network {
+          mbits = 20
+          port "lb" {
+            static = 9999
+          }
+          port "ui" {
+            static = 9998
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+
+# Write the chatapp.nomad job
+cat <<-EOF > /root/nomad/jobs/chatapp.nomad
+job "chat-app" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "chat-app" {
+    count = 3
+
+    update {
+      max_parallel     = 1
+      health_check     = "task_states"
+      min_healthy_time = "15s"
+      healthy_deadline = "2m"
+    }
+
+    network {
+      mode = "bridge"
+      port "http" {
+        static = 9002
+        to     = 5000
+      }
+    }
+
+    task "chat-app" {
+      driver = "docker"
+
+      config {
+        image = "lhaig/anon-app:0.02"
+      }
+
+      env {
+        "MONGODB_SERVER" = "127.0.0.1"
+        "MONGODB_PORT" = "27017"
+      }
+
+      resources {
+        cpu = 500 # MHz
+        memory = 512 # MB
+      }
+
+    } # end chat-app task
+
+    service {
+      name = "chat-app"
+      tags = ["chat-app"]
+      port = "http"
+
+      connect {
+        sidecar_service {
+          tags = ["chat-app-proxy"]
+          proxy {
+            upstreams {
+              destination_name = "mongodb"
+              local_bind_port = 27017
+            }
+          }
+        }
+      } # end connnect
+    } # end service
+
+  } # end chat-app group
+
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/solve-nomad-server-1
@@ -4,4 +4,31 @@
 HISTFILE=~/.bash_history
 set -o history
 
+# Change directory
+cd /root/nomad/jobs
+
+# Run mongodb Job
+nomad job run mongodb.nomad
+
+# Sleep
+sleep 30
+
+# Check mongodb job Status
+nomad job status mongodb
+
+# Run fabio Job
+nomad job run fabio.nomad
+
+# Sleep
+sleep 30
+
+# Run chat-app Job
+nomad job run chat-app.nomad
+
+# Sleep
+sleep 120
+
+# Check chat-app Status
+nomad job status chat-app
+
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/solve-nomad-server-1
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=~/.bash_history
+set -o history
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/rolling-update/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/rolling-update/check-nomad-server-1
@@ -2,7 +2,16 @@
 
 set -e
 
-#
-grep -q "" /root/.bash_history || fail-message "You haven't on the Nomad server yet."
+grep -q "cd /root/nomad/jobs" /root/.bash_history || fail-message "You have not navigated to /root/nomad/jobs on the Nomad server yet."
+
+grep -q "" /root/.bash_history || fail-message "You have not on the Nomad server yet."
+
+grep -q "dark-0.02" /root/nomad/jobs/chat-app.nomad || fail-message "You have not set the image tag to 'dark-0.02' in  chat-app.nomad on the Nomad server yet."
+
+grep -q "nomad job plan chat-app.nomad" /root/.bash_history || fail-message "You have not planned a new deployment of the chat-app job on the Nomad server yet."
+
+grep -q "nomad job run chat-app.nomad" /root/.bash_history || fail-message "You have not run the rolling update of the chat-app job on the Nomad server yet."
+
+grep -q "nomad job status chat-app" /root/.bash_history || fail-message "You have not checked the status of the rolling update of the chat-app job on the Nomad server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/rolling-update/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/rolling-update/check-nomad-server-1
@@ -1,0 +1,8 @@
+#!/bin/bash -l
+
+set -e
+
+#
+grep -q "" /root/.bash_history || fail-message "You haven't on the Nomad server yet."
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/rolling-update/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/rolling-update/setup-nomad-server-1
@@ -1,0 +1,8 @@
+#!/bin/bash -l
+
+set -e
+
+rm /root/.bash_history
+touch /root/.bash_history
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/rolling-update/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/rolling-update/solve-nomad-server-1
@@ -1,0 +1,7 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=~/.bash_history
+set -o history
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/rolling-update/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/rolling-update/solve-nomad-server-1
@@ -4,4 +4,22 @@
 HISTFILE=~/.bash_history
 set -o history
 
+# Change directory
+cd /root/nomad/jobs
+
+# Edit chat-app.nomad
+sed -i "s/anon-app:0.02/anon-app:dark-0.02/g" chat-app.nomad
+
+# Plan chat-app.nomad deployment
+nomad job plan chat-app.nomad
+
+# Run chat-app.nomad Job
+nomad job run chat-app.nomad
+
+# Sleep
+sleep 120
+
+# Check status of chat-app Job
+nomad job status chat-app
+
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/track.yml
+++ b/instruqt-tracks/nomad-update-strategies/track.yml
@@ -156,8 +156,8 @@ challenges:
     `<br>
     Fabio will automatically add a route for each instance of the chat app because of the "urlprefix-/" tag in the task group's "service" stanza.
 
-    Additionally, the task group has the following stanza:<br>
-    `
+    Additionally, the task group has the following stanza:
+    ```
     update {
       max_parallel = 1
       health_check = "checks"
@@ -165,9 +165,9 @@ challenges:
       healthy_deadline = "2m"
       # canary = 3
     }
-    `<br>
+    ```
 
-    This tells Nomad that it should update one instance of the task group at a time, base the health of each instance on its health checks, require a new allocation to be healthy for 15 seconds before marking it as healthy, and require a new allocation to be healthy after no more than 2 minutes; if an allocation is not healthy within 2 minutes, it will be marked as unhealthy. The "canary" attribute is commented out for now; we will uncomment it when doing blue/green and canary deployments later in this track.
+    This tells Nomad that it should update one instance of the task group at a time, base the health of each instance on its health checks, require a new allocation to be healthy for 15 seconds before marking it as healthy, and require a new allocation to be healthy after no more than 2 minutes; if an allocation is not healthy within 2 minutes, it will be marked as unhealthy. The "canary" attribute is commented out for now; you will uncomment it when doing blue/green and canary deployments later in this track.
 
     Finally, the "chat-app" task group uses Consul Connect [sidecar proxies](https://www.consul.io/docs/connect/proxies.html) to talk to the MongoDB database using mutual Transport Layer Security (mTLS) certificates. This is implemented by this stanza:<br>
     `
@@ -200,7 +200,7 @@ challenges:
     ==> Evaluation "83924539" finished with status "complete" "complete"
     `<br>
 
-    After waiting about 30 seconds, check the status of the "chat-app" job with this command on the "Server" tab:
+    After waiting about 60 seconds, check the status of the "chat-app" job with this command on the "Server" tab:
     ```
     nomad job status chat-app
     ```
@@ -218,11 +218,13 @@ challenges:
 
     You can also check out the "chat-app" job in the Nomad UI. Within 1 minute of running the job, all 3 allocations should be healthy.
 
-    You can also verify that the Nomad task groups were automatically regis†ered as Consul services by looking at the "Services" tab of the Consul UI. Note the sidecar proxy services created by Nomad's integration with Consul Connect.
+    You can also verify that the Nomad task groups were automatically registered as Consul services by looking at the "Services" tab of the Consul UI. Note the sidecar proxy services created by Nomad's integration with Consul Connect. The services all include node checks and service checks.
 
-    You can visit the chat-app UI on the "Chat 1", "Chat 2", and "Chat 3" tabs. You can send messages and then see them show up inside the chat-app UI on the other Chat tabs, but only after selecting those tabs and clicking the Instruqt refresh button.
+    You can visit the chat-app UI on the "Chat 1", "Chat 2", and "Chat 3" tabs and click the Instruqt refresh button for each of them to make them show up. Note that all instances of the chat app currently have a light background.
 
-    In the next challenge, you will update the Chat app using the rolling update strategy.
+    Since we are using Fabio, the 3 Chat tabs are not actually pinned to the 3 Nomad clients. Each time you click the refresh button for one of the tabs, you will be randomly connected to an instance of the app on any the 3 Nomad clients.
+
+    In the next challenge, you will update the Chat app to use a dark background using Nomad's rolling update strategy.
   notes:
   - type: text
     contents: |-
@@ -270,7 +272,7 @@ challenges:
   teaser: |
     Do a rolling update of the Chat job in which you replace one instance at a time.
   assignment: |-
-    In this challenge, you will do a rolling update of the Chat job.
+    In this challenge, you will do a rolling update of the "chat-app" job.
 
     Please navigate back to the /root/nomad/jobs directory on the "Server" tab again with this command:
     ```
@@ -306,29 +308,23 @@ challenges:
     nomad job run chat-app.nomad
     ```
 
-    In the Nomad UI, if you click the Instruqt refresh button and then select the "chat-app" job, you will see that there is a new deployment running. Over the next few minutes, you will see the numbers of placed and healthy allocations for this deployment increase to 3.
+    In the Nomad UI, if you select the "chat-app" job, you will see that there is a new deployment running. Over the next two minutes, you will see the numbers of placed and healthy allocations for this deployment increase to 3.
 
-    Alternatively, you could monitor the progress of the rolling update by periodically running `nomad deployment status <deployment_id>` where <deployment_id\> is the ID of the latest deployment shown in the Nomad UI.
+    As the number of healthy allocations increases, refresh the "Chat 1", "Chat 2", and "Chat 3" tabs periodically. Initially, you will only see the light background; but over the next 2 minutes as the rolling update proceeds, you will see the dark background 1/3 of the time, then 2/3 of the time, and then all the time.
 
-    As the number of healthy allocations increases, refresh the "Chat 1", "Chat 2", and "Chat 3" tabs to see what happens. The apps should change from a light to a dark background one at a time as the rolling update proceeds. The color of the "Send" button in the app will change from green to purple. Note that the order in which the apps are updated can vary.
-
-    If you happen to catch one of the apps while it is being redeployed, you will see a "Connecting to the service..." message. That is ok.
-
-    Since the chat messages are stored in the MongoDB database, the messages you previously sent will still show up.
-
-    After all the chat-app allocations are healthy and the chat-app clients have the dark background, run the following command on the "Server" tab:
+    After all the chat-app allocations are healthy and the chat-app clients only show the dark background, run the following command on the "Server" tab:
     ```
     nomad job status chat-app
     ```
     You will now see 6 allocations, 3 of which are marked "complete" while 3 are "running".
 
-    In the next challenge, you will update the Chat app using a blue/green deployment strategy.
+    In the next challenge, you will update the Chat app using a "blue/green" deployment strategy.
   notes:
   - type: text
     contents: |-
-      In this challenge, you will do a rolling update of the Chat job.
+      In this challenge, you will do a rolling update of the Chat job to make it use a dark background instead of the current light background.
 
-      In the next challenge, you will update the Chat app using a blue/green deployment strategy.
+      In the next challenge, you will update the Chat app using a "blue/green" deployment strategy.
   tabs:
   - title: Jobs
     type: code
@@ -362,7 +358,7 @@ challenges:
     hostname: nomad-client-3
     port: 9999
   difficulty: basic
-  timelimit: 3600
+  timelimit: 600
 - slug: blue-green-deployment
   id: 2o5tzi8hyd5f
   type: challenge
@@ -390,7 +386,7 @@ challenges:
     sed -i "s/dark-0.02/0.02/g" chat-app.nomad
     ```
 
-    Setting the "canary" attribute to the "count" attribute of the "chat-app" task group tells Nomad to deploy 3 new "green" instances of the task group as part of a blue/green deployment in which the 3 "blue" instances that are running the dark version of the chat app continue to run even after the new "green" instances that will run the "light" version of the chat app are deployed. (Note that the colors "blue" and "green" here have nothing to do with the changing background colors of the chat app; they are just standard terminology for referring to this particular update pattern.)
+    Setting the "canary" attribute to the "count" attribute of the "chat-app" task group tells Nomad to deploy 3 new instances of the task group as part of a "blue/green" deployment in which the 3 "blue" instances of the chat app with the dark background continue to run even after the new "green" instances of the chat app with the light background are deployed. (Note that the colors "blue" and "green" here have nothing to do with the background colors of the chat app; they are just standard terminology for referring to this particular update strategy.)
 
     Now, check what would happen if you redeployed the "chat-app" job with this command on the "Server" tab:
     ```
@@ -405,12 +401,12 @@ challenges:
           AutoPromote:      "false"
           AutoRevert:       "false"
         +/- Canary:           "0" => "3"
-          HealthCheck:      "checks"
-          HealthyDeadline:  "120000000000"
-          MaxParallel:      "1"
-          MinHealthyTime:   "15000000000"
-          ProgressDeadline: "600000000000"
-        }
+            HealthCheck:      "checks"
+            HealthyDeadline:  "120000000000"
+            MaxParallel:      "1"
+            MinHealthyTime:   "15000000000"
+            ProgressDeadline: "600000000000"
+          }
       +/- Task: "chat-app" (forces create/destroy update)
         +/- Config {
           +/- image: "lhaig/anon-app:dark-0.02" => "lhaig/anon-app:0.02"
@@ -418,7 +414,7 @@ challenges:
           Task: "connect-proxy-chat-app"
     `<br>
 
-    The plan indicates that Nomad would create 3 canaries to run the "0.02" version of the chat app but ignore the 3 allocations that are currently running. That would result in 6 instances of the chat app running on the 3 Nomad clients. That is ok, however, since we are using ports dynamically selected by Nomad and are using Fabio to forward requests to the chat app clients.
+    The plan indicates that Nomad would create 3 canaries to run the "0.02" version of the chat app but ignore the 3 allocations that are currently running. That would result in 6 instances of the chat app running on the 3 Nomad clients. That is ok, however, since we are using ports dynamically selected by Nomad and are using Fabio to forward requests to the chat app instances.
 
     Go ahead and re-run the "chat-app" job with this command:
     ```
@@ -437,35 +433,37 @@ challenges:
     ==> Evaluation "81ca49f4" finished with status "complete"
     `<br>
 
-    If you look at the chat-app job in the Nomad UI, you will see that there are 6 allocations running.  As you watch the current deployment, you will see the number of canaries climb to "3/3". You will also see an organge "Promote Canary" button and a message saying "Deployment is running but requires manual promotion".
+    If you look at the chat-app job in the Nomad UI, you will see that there are 6 allocations running. You will also see an orange "Promote Canary" button and a message saying "Deployment is running but requires manual promotion".
 
     Check the status of the "chat-app" job by running this command:
     ```
     nomad job status chat-app
     ```
-    The "Deployed" section should show "false" in the "Promoted" column along with 3 desired, 3 canaries, 3 placed, and 3 healthy instances. The "Allocations" section at the bottom should show 6 running and 3 stopped allocations. The latter are from when you did the rolling update in the last challenge.
+    The "Deployed" section should eventually show "false" in the "Promoted" column along with 3 desired, 3 canaries, 3 placed, and 3 healthy instances. The "Allocations" section at the bottom should show 6 running and 3 stopped allocations. The latter are from when you did the rolling update in the last challenge.
 
-    If you select the "Fabio UI" tab and click the Instruqt refresh button, you will see that Fabio now has 6 routes. If you refresh the "Chat 1", "Chat 2", and "Chat 3" tabs, you will still only see the version of the app with the dark background because Fabio uses sticky sessions and keeps the 3 tabs connected to the chat app instances it had already connected them to.
+    If you select the "Fabio UI" tab and click the Instruqt refresh button, you will see that Fabio now has 6 routes.
+
+    If you refresh the "Chat 1", "Chat 2", and "Chat 3" tabs, you will see the app with both the light and the dark backgrounds. Each background should show up 50% of the time since all 6 allocations are active at this point.
 
     Next, you can promote the "green" allocations by running this command:<br>
     `
     nomad deployment promote <deployment_id>
     `<br>
-    replacing <deployment_id\> with the deployment ID returned by the last command. Alternatively, you could click the orange "Promote Canary" button in the Nomad UI.
+    replacing <deployment_id\> with the deployment ID of the active deployment returned by the job status command. Alternatively, you could click the orange "Promote Canary" button in the Nomad UI.
 
-    After clicking the Instruqt refresh button for the Nomad UI and selecting the "chat-app" job, you should see that the number of running clients has changed to 3.
+    After clicking the Instruqt refresh button for the Nomad UI and selecting the "chat-app" job, you should see that the number of running clients has changed to 3. If you run the job status command again, you will now see 3 running and 6 stopped allocations.
 
     Now, when you refresh the the "Chat 1", "Chat 2", and "Chat 3" tabs, you will only see the version of the chat app with the light background since the allocations with the dark background have been stopped by Nomad.
 
-    If you had been unhappy with the new version of the chat app, you could have rolled back to the old version by running `nomad deployment fail <deployment_id>`, replacing <deployment_id\> with the deployment ID returned by the job status command. Nomad would then stop the new allocations leaving the app in the state it had been in before you re-ran the job.
+    If you had been unhappy with the new version of the chat app, you could have rolled back to the old version by running `nomad deployment fail <deployment_id>`, replacing <deployment_id\> with the deployment ID returned by the job status command. Nomad would then have stopped the new allocations leaving the app in the state it had been in before you re-ran the job.
 
-    In the next challenge, you will update the Chat job using a canary deployment.
+    In the next challenge, you will update the Chat job using a "canary" deployment, but you will rollback the deployment instead of promoting it.
   notes:
   - type: text
     contents: |-
-      In this challenge, you will do a "blue/green" deployment of the Chat job. This means that you will initally deploy 3 new instances of the chat app with the original light background but keep the 3 instances with the dark background running. When you are satisfied with the new instances, you will promote the deployment, causing Nomad to stop the old instances.
+      In this challenge, you will do a "blue/green" deployment of the Chat job. This means that you will initally deploy 3 new instances of the chat app with the original light background but keep the 3 instances with the dark background running. When you are satisfied with the new version of the app, you will promote the deployment, causing Nomad to stop the old instances.
 
-      In the next challenge, you will update the Chat job using a canary deployment.
+      In the next challenge, you will update the Chat job using a "canary" deployment, but you will rollback the deployment instead of promoting it.
   tabs:
   - title: Jobs
     type: code
@@ -499,7 +497,7 @@ challenges:
     hostname: nomad-client-3
     port: 9999
   difficulty: basic
-  timelimit: 3600
+  timelimit: 600
 - slug: canary-deployment
   id: 8sbd1wqgtqir
   type: challenge
@@ -507,9 +505,105 @@ challenges:
   teaser: |
     Do a canary deployment of the Chat job in which you deploy and evaluate 1 new instance but decide to roll back the deployment.
   assignment: |-
-    In this challenge, you will do a canary deployment of the chat-app job.
+    In this challenge, you will do a "canary" deployment of the chat-app job, but you will rollback the deployment instead of promoting it.
 
-    This means that you will initally deploy 1 new "canary" instance of the chat app with the dark background but keep the 3 instances with the light background that you deployed in the last challenge running. When you are satisfied with the canary, you will promote the deployment, causing Nomad to do a rolling update to replace the 3 older instances.
+    This means that you will deploy 1 new "canary" instance of the chat app with the dark background but keep the 3 instances with the light background that you deployed in the last challenge running. You will then roll back the deployment with the `nomad deployment fail` command.
+
+    Please navigate back to the /root/nomad/jobs directory on the "Server" tab again with this command:
+    ```
+    cd /root/nomad/jobs
+    ```
+
+    Edit the "chat-app.nomad" job specification file on the "Jobs" tab, making the following changes:
+
+      1. Change the line with `canary = 3` in the "update" stanza to `canary = 1`.
+      2. Change the "0.02" tag on the image to "dark-0.02".
+
+    If you prefer, you can use these commands to edit the file for you:
+    ```
+    sed -i "s/canary = 3/canary = 1/g" chat-app.nomad
+    sed -i "s/0.02/dark-0.02/g" chat-app.nomad
+    ```
+
+    Setting the "canary" attribute to "1" tells Nomad to deploy a single "canary" instances of the chat app with the dark background while leaving the 3 instances with the light background running.
+
+    Now, check what would happen if you redeployed the "chat-app" job with this command on the "Server" tab:
+    ```
+    nomad job plan chat-app.nomad
+    ```
+
+    This should return something like this:<br>
+    `
+    +/- Job: "chat-app"
+    +/- Task Group: "chat-app" (1 canary, 3 ignore)
+      +/- Update {
+          AutoPromote:      "false"
+          AutoRevert:       "false"
+        +/- Canary:           "3" => "1"
+            HealthCheck:      "checks"
+            HealthyDeadline:  "120000000000"
+            MaxParallel:      "1"
+            MinHealthyTime:   "15000000000"
+            ProgressDeadline: "600000000000"
+          }
+      +/- Task: "chat-app" (forces create/destroy update)
+        +/- Config {
+          +/- image: "lhaig/anon-app:0.02" => "lhaig/anon-app:dark-0.02"
+            }
+          Task: "connect-proxy-chat-app"
+    `<br>
+
+    The plan indicates that Nomad would create 1 canary to run the "dark-0.02" version of the chat app but ignore the 3 allocations that are currently running. That would result in 4 instances of the chat app running on the 3 Nomad clients.
+
+    Go ahead and re-run the "chat-app" job with this command:
+    ```
+    nomad job run chat-app.nomad
+    ```
+
+    This should return something like this:<br>
+    `
+    ==> Monitoring evaluation "0fd02bb5"
+        Evaluation triggered by job "chat-app"
+        Evaluation within deployment: "fa80df0c"
+        Allocation "7633b926" created: node "14e04978", group "chat-app"
+        Evaluation status changed: "pending" -> "complete"
+    ==> Evaluation "0fd02bb5" finished with status "complete"
+    `<br>
+
+    If you look at the chat-app job in the Nomad UI, you will see that there are 4 allocations running. You will also see an orange "Promote Canary" button as in the last challenge. Additionally, the active deployment will show "1/1" Canaries, 1 Placed, 3 Desired, and 1 Healthy allocation.
+
+    The fact that the active deployment only has 1 healthy allocation might worry you, but this is actually ok; it just means that Nomad still plans on deploying 2 more allocations with the new version of the app if you do promote the canary. In other words, since the "count" of the "chat-app" task group is 3, Nomad will always want to deploy 3 allocations as part of any deployment of the job. By specifying 1 canary, you forced Nomad to delay the other 2 allocations.
+
+    Check the status of the "chat-app" job by running this command:
+    ```
+    nomad job status chat-app
+    ```
+    The "Deployed" section should show "false" in the "Promoted" column along with 3 desired, 1 canary, 1 placed, and 1 healthy instances, agreeing with what the active deployment in the Nomad UI showed. The "Allocations" section at the bottom should show 4 running and 6 stopped allocations. The latter are from when you did the rolling and blue/green updates in the last two challenges.
+
+    If you select the "Fabio UI" tab and click the Instruqt refresh button, you will see that Fabio now has 4 routes. If you refresh the "Chat 1", "Chat 2", and "Chat 3" tabs, you will see the app with both the light and the dark backgrounds. However, the dark background should only show up 1/4 of the time. That makes sense since you are running 3 instances of the chat app with the light background from the last challenge along with the single canary that uses the dark background.
+
+    Let's assume that you like the light background of the app better than the dark background that the canary is using and want to roll back the deployment.
+
+    Do that by running this command on the "Server" tab:<br>
+    `
+    nomad deployment fail <deployment_id>
+    `<br>
+    replacing <deployment_id\> with the deployment ID of the latest deployment returned by the job status command.
+
+    Nomad returns a message like this:<br>
+    `
+    Deployment "fa80df0c-0ba8-327a-3ad3-a8e383fe64e1" failed
+    ==> Monitoring evaluation "0c2e95f1"
+        Evaluation triggered by job "chat-app"
+        Evaluation within deployment: "fa80df0c"
+        Evaluation status changed: "pending" -> "complete"
+    ==> Evaluation "0c2e95f1" finished with status "complete"
+    `<br>
+    This indicates that Nomad has failed the deployment. The Nomad UI will also show a message "Deployment marked as failed".
+
+    While the message does not say is that Nomad will stop the canary allocation and leave the 3 allocations with the light background running. However, you can confirm that this has happened by refreshing the Chat tabs multiple times. You will only see the light background.
+
+    Together, this challenge and the previous one show that you can test out changes to an application with Nomad and then either promote the changes or roll them back. The choice is yours.
 
     Congratulations on completing the Nomad Job Update Strategies track!
   notes:
@@ -517,7 +611,9 @@ challenges:
     contents: |-
       In this challenge, you will do a "canary" deployment of the Chat job.
 
-      This means that you will initally deploy 1 new "canary" instance of the chat app with the dark background but keep the 3 instances with the light background that you deployed in the last challenge running. When you are satisfied with the canary, you will promote the deployment, causing Nomad to do a rolling update to replace the 3 older instances.
+      This means that you will deploy 1 new "canary" instance of the chat app with the dark background but keep the 3 instances with the light background that you deployed in the last challenge running.
+
+      However, instead of promoting the deployment, you will roll it back.
   tabs:
   - title: Jobs
     type: code
@@ -551,5 +647,5 @@ challenges:
     hostname: nomad-client-3
     port: 9999
   difficulty: basic
-  timelimit: 3600
-checksum: "11399941958673161602"
+  timelimit: 600
+checksum: "6853214861076601752"

--- a/instruqt-tracks/nomad-update-strategies/track.yml
+++ b/instruqt-tracks/nomad-update-strategies/track.yml
@@ -9,6 +9,8 @@ description: |-
 
   This track will guide you through implementing these update strategies based on the [Nomad Job Update Strategies](https://learn.hashicorp.com/nomad/update-strategies) guide.
 
+  You will run "mongodb", "fabio", and  "chat-app" jobs and update the last using rolling, blue/green, and canary update strategies. Fabio will be used as a reverse proxy server that will forward requests to instances of the "chat" application which will store its chat messages in a single MongoDB database.
+
   Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics), [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster), and [Nomad Multi-Server Cluster](https://instruqt.com/hashicorp/tracks/nomad-multi-server-cluster) tracks.
 icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
 tags:
@@ -60,12 +62,8 @@ challenges:
     contents: |-
       In this challenge, you will verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-      In later challenges, you will run chatapp and mongodb jobs and update the first using rolling, blue/green, and canary update strategies.
+      In later challenges, you will run "mongodb", "fabio", and  "chat-app" jobs and update the last using rolling, blue/green, and canary update strategies. Fabio will be used as a reverse proxy server that will forward requests to instances of the "chat" application which will store its messages in a single MongoDB database.
   tabs:
-  - title: Jobs
-    type: code
-    hostname: nomad-server-1
-    path: /root/nomad/jobs/
   - title: Server
     type: terminal
     hostname: nomad-server-1
@@ -82,11 +80,11 @@ challenges:
 - slug: deploy-the-jobs
   id: tglnvylrrmeo
   type: challenge
-  title: Deploy the Chat and MongoDB Jobs
+  title: Deploy the MongoDB, Fabio, and Chat-App Jobs
   teaser: |
-    Deploy the initial versions of the Chat and MongoDB jobs.
+    Deploy the MongoDB, Fabio, and Chat-App jobs.
   assignment: |-
-    In this challenge, you will deploy the inital versions of the Chat and MongoDB jobs.
+    In this challenge, you will deploy the "mongodb", "fabio", and "chat-app" jobs.
 
     Inspect the "mongodb.nomad" job specification file on the "Jobs" tab. This will deploy a "db" task group that runs the MongoDB database on port 27017 from the "mongo" Docker image.
 
@@ -113,23 +111,63 @@ challenges:
 
     You can check the job in the Nomad UI after waiting 15-30 seconds, clicking the Instruqt refresh button above the Nomad UI, and then selecting the "mongodb" job. You might need to make your browser window a bit wider to see the UI properly and so that the Instruqt buttons do not overlap the Nomad UI tab. You could also click the rectangular button next to the refresh button to hide this assignment. After no more than 1 minute, you should see that the job has 1 healthy allocation.
 
-    Alternatively, you can run the `nomad job status mongodb` command on the "Server" tab to check the status of the job and validate that the "db" task group is healthy.
+    Alternatively, you can run the command:
+    ```
+    nomad job status mongodb
+    ```
+    on the "Server" tab to check the status of the "mongodb" job and validate that the "db" task group is healthy.
 
-    Next, inspect the "chatapp.nomad" job specification file on the "Jobs" tab. This job deploys 3 instances of a "chat-app" task group that runs a custom Docker image, "lhaig/anon-app:0.02" created by two HashiCorp solutions engineers, Guy Barrows and Lance Haig. Note that the job specifies the "0.02" tag. Later, when we update the app in various ways, we will specify a different tag to use a different version of it.
+    Next, inspect the "fabio.nomad" job specification file on the "Jobs" tab. This job deploys the reverse proxy server [Fabio](https://fabiolb.net) as a system job on all the Nomad clients from a Docker image. Since it is a system job, no "count" is specified for the "fabio" task group. Fabio will automatically detect certain services registered in Consul and route requests to Fabio's port, 9999, to dynamic ports selected by Nomad for those services.
 
-    The "chat-app" task group runs on the static port 9002 on the Nomad clients; that port is mapped to port 5000 inside the Docker containers.
+    Run the "fabio.nomad" job on the "Server" tab with this command:
+    ```
+    nomad job run fabio.nomad
+    ```
+    This should return something like this:<br>
+    `
+    ==> Monitoring evaluation "d08fff01"
+    Evaluation triggered by job "fabio"
+    Allocation "d17c329d" created: node "211ec400", group "fabio"
+    Allocation "ac529c74" created: node "7de22213", group "fabio"
+    Allocation "c857996d" created: node "9c9b53e9", group "fabio"
+    Evaluation status changed: "pending" -> "complete"
+    ==> Evaluation "d08fff01" finished with status "complete"
+    `<br>
+    Since this is a system job, the node IDs for the 3 allocations are all distinct; one instance of the "fabio" task group is deployed to each Nomad client.
+
+    Next, inspect the "chat-app.nomad" job specification file on the "Jobs" tab. This job deploys 3 instances of a "chat-app" task group that runs a custom Docker image, "lhaig/anon-app:0.02" created by two HashiCorp solutions engineers, Guy Barrows and Lance Haig. Note that the job specifies the "0.02" tag for that image. Later, when we update the app in various ways, we will specify a different tag to use a different version of it.
+
+    One instance of the chat-app task group will be deployed to each Nomad client because of the job's use of the "spread" stanza:<br>
+    `
+    spread {
+      attribute = "${node.unique.name}"
+    }
+    `<br>
+    Later, when we do a blue-green deployment, we will see that the new "green" deployments will also be spread evenly across the 3 Nomad clients.
+
+    The "chat-app" task runs on a dynamic port selected by Nomad; that port is mapped to port 5000 inside the task group's "network" stanza:<br>
+    `
+    network {
+      mode = "bridge"
+      port "http" {
+        to = 5000
+      }
+    }
+    `<br>
+    Fabio will automatically add a route for each instance of the chat app because of the "urlprefix-/" tag in the task group's "service" stanza.
 
     Additionally, the task group has the following stanza:<br>
     `
     update {
-      max_parallel     = 1
-      health_check     = "task_states"
+      max_parallel = 1
+      health_check = "checks"
       min_healthy_time = "15s"
       healthy_deadline = "2m"
+      # canary = 3
     }
     `<br>
 
-    This tells Nomad that it should update one instance of the task group at a time, base the health of each instance on the state of its tasks, require a new allocation to be healthy for 15 seconds before marking it as healthy, and require a new allocation to be healthy after no more than 2 minutes; if an allocation is not healthy within 2 minutes, it will be marked as unhealthy.
+    This tells Nomad that it should update one instance of the task group at a time, base the health of each instance on its health checks, require a new allocation to be healthy for 15 seconds before marking it as healthy, and require a new allocation to be healthy after no more than 2 minutes; if an allocation is not healthy within 2 minutes, it will be marked as unhealthy. The "canary" attribute is commented out for now; we will uncomment it when doing blue/green and canary deployments later in this track.
 
     Finally, the "chat-app" task group uses Consul Connect [sidecar proxies](https://www.consul.io/docs/connect/proxies.html) to talk to the MongoDB database using mutual Transport Layer Security (mTLS) certificates. This is implemented by this stanza:<br>
     `
@@ -143,12 +181,12 @@ challenges:
           }
         }
       }
-    } # end connnect
+    }
     `<br>
 
-    Run the "chatapp.nomad" job on the "Server" tab with this command:
+    Run the "chat-app.nomad" job on the "Server" tab with this command:
     ```
-    nomad job run chatapp.nomad
+    nomad job run chat-app.nomad
     ```
     This should return something like this:<br>
     `
@@ -176,7 +214,7 @@ challenges:
     ca660509  48f9e81c  chat-app    0        run      running  21s ago  14s ago
     `<br>
 
-    Note that the Node IDs of the 3 allocations are all different. In other words, Nomad scheduled one instance of the chat-app task to each Nomad client. It had to do this because we used the static port 9002 which would prevent more than one instance of the app running on any of the Nomad clients.
+    Note that the Node IDs of the 3 allocations are all different. In other words, Nomad scheduled one instance of the chat-app task to each Nomad client because of the `spread` stanza we included in the "chat-app.nomad" job specification.
 
     You can also check out the "chat-app" job in the Nomad UI. Within 1 minute of running the job, all 3 allocations should be healthy.
 
@@ -188,7 +226,7 @@ challenges:
   notes:
   - type: text
     contents: |-
-      In this challenge, you will deploy the inital versions of the Chat and MongoDB jobs.
+      In this challenge, you will deploy the "mongodb", "fabio", and "chat-app" jobs.
 
       In the next challenge, you will update the Chat app using the rolling update strategy.
   tabs:
@@ -214,15 +252,15 @@ challenges:
   - title: Chat 1
     type: service
     hostname: nomad-client-1
-    port: 9002
+    port: 9999
   - title: Chat 2
     type: service
     hostname: nomad-client-2
-    port: 9002
+    port: 9999
   - title: Chat 3
     type: service
     hostname: nomad-client-3
-    port: 9002
+    port: 9999
   difficulty: basic
   timelimit: 600
 - slug: rolling-update
@@ -230,7 +268,7 @@ challenges:
   type: challenge
   title: Do a Rolling Update of the Chat Job
   teaser: |
-    Do a rolling update of the Chat job.
+    Do a rolling update of the Chat job in which you replace one instance at a time.
   assignment: |-
     In this challenge, you will do a rolling update of the Chat job.
 
@@ -243,12 +281,12 @@ challenges:
 
     If you prefer, you could just run this command instead of editing the file yourself:
     ```
-    sed -i "s/anon-app:0.02/anon-app:dark-0.02/g" chatapp.nomad
+    sed -i "s/anon-app:0.02/anon-app:dark-0.02/g" chat-app.nomad
     ```
 
-    Now, check what would happen if you redeployed the application with this command:
+    Now, check what would happen if you redeployed the "chat-app" job with this command:
     ```
-    nomad job plan chatapp.nomad
+    nomad job plan chat-app.nomad
     ```
 
     This should return the following text:<br>
@@ -263,9 +301,9 @@ challenges:
     `<br>
     This indicates that Nomad would initially only update 1 of the 3 allocations, confirming that it would do a rolling update.
 
-    Go ahead and actually run a rolling update of the chat-app application:
+    Go ahead and actually run a rolling update of the chat application:
     ```
-    nomad job run chatapp.nomad
+    nomad job run chat-app.nomad
     ```
 
     In the Nomad UI, if you click the Instruqt refresh button and then select the "chat-app" job, you will see that there is a new deployment running. Over the next few minutes, you will see the numbers of placed and healthy allocations for this deployment increase to 3.
@@ -314,15 +352,15 @@ challenges:
   - title: Chat 1
     type: service
     hostname: nomad-client-1
-    port: 9002
+    port: 9999
   - title: Chat 2
     type: service
     hostname: nomad-client-2
-    port: 9002
+    port: 9999
   - title: Chat 3
     type: service
     hostname: nomad-client-3
-    port: 9002
+    port: 9999
   difficulty: basic
   timelimit: 3600
 - slug: blue-green-deployment
@@ -330,9 +368,11 @@ challenges:
   type: challenge
   title: Do a Blue/Green Deployment of the Chat Job
   teaser: |
-    Do a blue/green deployment of the Chat job.
+    Do a blue/green deployment of the Chat job in which you deploy 3 new instances alongside the current ones and then promote the deployment when satisfied.
   assignment: |-
     In this challenge, you will do a blue/green deployment of the Chat job.
+
+    This means that you will initally deploy 3 new instances of the chat app with the original light background but keep the 3 instances with the dark background running. When you are satisfied with the new instances, you will promote the deployment, causing Nomad to stop the old instances.
 
     Please navigate back to the /root/nomad/jobs directory on the "Server" tab again with this command:
     ```
@@ -341,14 +381,89 @@ challenges:
 
     Edit the "chat-app.nomad" job specification file on the "Jobs" tab, making the following changes:
 
-      1. Change the "dark-0.02" tag on the image back to "0.02".
-      2.
+      1. Uncomment the line with `canary = 3` in the "update" stanza by removing `# ` from before it.
+      2. Change the "dark-0.02" tag on the image back to "0.02".
+
+    If you prefer, you can use these commands to edit the file for you:
+    ```
+    sed -i "s/# canary = 3/canary = 3/g" chat-app.nomad
+    sed -i "s/dark-0.02/0.02/g" chat-app.nomad
+    ```
+
+    Setting the "canary" attribute to the "count" attribute of the "chat-app" task group tells Nomad to deploy 3 new "green" instances of the task group as part of a blue/green deployment in which the 3 "blue" instances that are running the dark version of the chat app continue to run even after the new "green" instances that will run the "light" version of the chat app are deployed. (Note that the colors "blue" and "green" here have nothing to do with the changing background colors of the chat app; they are just standard terminology for referring to this particular update pattern.)
+
+    Now, check what would happen if you redeployed the "chat-app" job with this command on the "Server" tab:
+    ```
+    nomad job plan chat-app.nomad
+    ```
+
+    This should return something like this:<br>
+    `
+    +/- Job: "chat-app"
+    +/- Task Group: "chat-app" (3 canary, 3 ignore)
+      +/- Update {
+          AutoPromote:      "false"
+          AutoRevert:       "false"
+        +/- Canary:           "0" => "3"
+          HealthCheck:      "checks"
+          HealthyDeadline:  "120000000000"
+          MaxParallel:      "1"
+          MinHealthyTime:   "15000000000"
+          ProgressDeadline: "600000000000"
+        }
+      +/- Task: "chat-app" (forces create/destroy update)
+        +/- Config {
+          +/- image: "lhaig/anon-app:dark-0.02" => "lhaig/anon-app:0.02"
+            }
+          Task: "connect-proxy-chat-app"
+    `<br>
+
+    The plan indicates that Nomad would create 3 canaries to run the "0.02" version of the chat app but ignore the 3 allocations that are currently running. That would result in 6 instances of the chat app running on the 3 Nomad clients. That is ok, however, since we are using ports dynamically selected by Nomad and are using Fabio to forward requests to the chat app clients.
+
+    Go ahead and re-run the "chat-app" job with this command:
+    ```
+    nomad job run chat-app.nomad
+    ```
+
+    This should return something like this:<br>
+    `
+    ==> Monitoring evaluation "81ca49f4"
+    Evaluation triggered by job "chat-app"
+    Evaluation within deployment: "916c6388"
+    Allocation "0803dbf0" created: node "c645cab8", group "chat-app"
+    Allocation "b8f8e7c2" created: node "ded26beb", group "chat-app"
+    Allocation "e57ae40c" created: node "f9ce3ddf", group "chat-app"
+    Evaluation status changed: "pending" -> "complete"
+    ==> Evaluation "81ca49f4" finished with status "complete"
+    `<br>
+
+    If you look at the chat-app job in the Nomad UI, you will see that there are 6 allocations running.  As you watch the current deployment, you will see the number of canaries climb to "3/3". You will also see an organge "Promote Canary" button and a message saying "Deployment is running but requires manual promotion".
+
+    Check the status of the "chat-app" job by running this command:
+    ```
+    nomad job status chat-app
+    ```
+    The "Deployed" section should show "false" in the "Promoted" column along with 3 desired, 3 canaries, 3 placed, and 3 healthy instances. The "Allocations" section at the bottom should show 6 running and 3 stopped allocations. The latter are from when you did the rolling update in the last challenge.
+
+    If you select the "Fabio UI" tab and click the Instruqt refresh button, you will see that Fabio now has 6 routes. If you refresh the "Chat 1", "Chat 2", and "Chat 3" tabs, you will still only see the version of the app with the dark background because Fabio uses sticky sessions and keeps the 3 tabs connected to the chat app instances it had already connected them to.
+
+    Next, you can promote the "green" allocations by running this command:<br>
+    `
+    nomad deployment promote <deployment_id>
+    `<br>
+    replacing <deployment_id\> with the deployment ID returned by the last command. Alternatively, you could click the orange "Promote Canary" button in the Nomad UI.
+
+    After clicking the Instruqt refresh button for the Nomad UI and selecting the "chat-app" job, you should see that the number of running clients has changed to 3.
+
+    Now, when you refresh the the "Chat 1", "Chat 2", and "Chat 3" tabs, you will only see the version of the chat app with the light background since the allocations with the dark background have been stopped by Nomad.
+
+    If you had been unhappy with the new version of the chat app, you could have rolled back to the old version by running `nomad deployment fail <deployment_id>`, replacing <deployment_id\> with the deployment ID returned by the job status command. Nomad would then stop the new allocations leaving the app in the state it had been in before you re-ran the job.
 
     In the next challenge, you will update the Chat job using a canary deployment.
   notes:
   - type: text
     contents: |-
-      In this challenge, you will do a blue/green deployment of the Chat job.
+      In this challenge, you will do a "blue/green" deployment of the Chat job. This means that you will initally deploy 3 new instances of the chat app with the original light background but keep the 3 instances with the dark background running. When you are satisfied with the new instances, you will promote the deployment, causing Nomad to stop the old instances.
 
       In the next challenge, you will update the Chat job using a canary deployment.
   tabs:
@@ -374,15 +489,15 @@ challenges:
   - title: Chat 1
     type: service
     hostname: nomad-client-1
-    port: 9002
+    port: 9999
   - title: Chat 2
     type: service
     hostname: nomad-client-2
-    port: 9002
+    port: 9999
   - title: Chat 3
     type: service
     hostname: nomad-client-3
-    port: 9002
+    port: 9999
   difficulty: basic
   timelimit: 3600
 - slug: canary-deployment
@@ -390,17 +505,19 @@ challenges:
   type: challenge
   title: Do a Canary Deployment of the Chat Job
   teaser: |
-    Do a canary deployment of the Chat job.
+    Do a canary deployment of the Chat job in which you deploy and evaluate 1 new instance but decide to roll back the deployment.
   assignment: |-
-    In this challenge, you will do a canary deployment of the Chat job.
+    In this challenge, you will do a canary deployment of the chat-app job.
+
+    This means that you will initally deploy 1 new "canary" instance of the chat app with the dark background but keep the 3 instances with the light background that you deployed in the last challenge running. When you are satisfied with the canary, you will promote the deployment, causing Nomad to do a rolling update to replace the 3 older instances.
 
     Congratulations on completing the Nomad Job Update Strategies track!
   notes:
   - type: text
     contents: |-
-      In this challenge, you will do a canary deployment of the Chat job.
+      In this challenge, you will do a "canary" deployment of the Chat job.
 
-      In a canary deployment, one or more additional allocations of the job are deployed while Nomad continues to run the original allocations. This gives operators a chance to verify that the new version of the job is behaving correctly before completely replacing the old version.
+      This means that you will initally deploy 1 new "canary" instance of the chat app with the dark background but keep the 3 instances with the light background that you deployed in the last challenge running. When you are satisfied with the canary, you will promote the deployment, causing Nomad to do a rolling update to replace the 3 older instances.
   tabs:
   - title: Jobs
     type: code
@@ -424,15 +541,15 @@ challenges:
   - title: Chat 1
     type: service
     hostname: nomad-client-1
-    port: 9002
+    port: 9999
   - title: Chat 2
     type: service
     hostname: nomad-client-2
-    port: 9002
+    port: 9999
   - title: Chat 3
     type: service
     hostname: nomad-client-3
-    port: 9002
+    port: 9999
   difficulty: basic
   timelimit: 3600
-checksum: "13723511898125120825"
+checksum: "11399941958673161602"

--- a/instruqt-tracks/nomad-update-strategies/track.yml
+++ b/instruqt-tracks/nomad-update-strategies/track.yml
@@ -1,0 +1,438 @@
+slug: nomad-update-strategies
+id: ijfbyi1drwpu
+type: track
+title: Nomad Job Update Strategies
+teaser: |
+  Explore Nomad job update strategies including rolling, blue/green, and canary updates.
+description: |-
+  Most applications are long-lived and require updates over time. Whether you are deploying a new version of your web application or updating to a new version of a database, Nomad has built-in support for rolling, blue/green, and canary updates.
+
+  This track will guide you through implementing these update strategies based on the [Nomad Job Update Strategies](https://learn.hashicorp.com/nomad/update-strategies) guide.
+
+  Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics), [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster), and [Nomad Multi-Server Cluster](https://instruqt.com/hashicorp/tracks/nomad-multi-server-cluster) tracks.
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
+tags:
+- Nomad
+- updates
+- rolling
+- blue/green
+- canary
+owner: hashicorp
+developers:
+- roger@hashicorp.com
+private: true
+published: true
+challenges:
+- slug: verify-nomad-cluster-health
+  id: ehjpxbybs49x
+  type: challenge
+  title: Verify the Health of Your Nomad Enterprise Cluster
+  teaser: |
+    Verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts.
+  assignment: |-
+    In this challenge, you will verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
+
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients. The [Consul Connect integration](https://nomadproject.io/guides/integrations/consul-connect) has been enabled on the server and clients since the chatapp uses it to talk to the MongoDB database. Additionally, a Nomad [host volume](https://nomadproject.io/docs/configuration/client/#host_volume-stanza) called "mongodb_mount" has been configured on the clients under the /opt/mongodb/data directory so that MongoDB can persist its data.
+
+    First, verify that all 4 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
+    ```
+    consul members
+    ```
+    You should see 4 Consul agents with the "alive" status.
+
+    Check that the Nomad server is running by running this command on the "Server" tab:
+    ```
+    nomad server members
+    ```
+    You should see 1 Nomad server with the "alive" status.
+
+    Check the status of the Nomad client nodes by running this command on the "Server" tab:
+    ```
+    nomad node status
+    ```
+    You should see 3 Nomad clients with the "ready" status.
+
+    You can also check the status of the Nomad server and clients in the Nomad and Consul UIs.
+
+    In the next challenge, you will configure Nomad Enterprise namespaces and resource quotas.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
+
+      In later challenges, you will run chatapp and mongodb jobs and update the first using rolling, blue/green, and canary update strategies.
+  tabs:
+  - title: Jobs
+    type: code
+    hostname: nomad-server-1
+    path: /root/nomad/jobs/
+  - title: Server
+    type: terminal
+    hostname: nomad-server-1
+  - title: Consul UI
+    type: service
+    hostname: nomad-server-1
+    port: 8500
+  - title: Nomad UI
+    type: service
+    hostname: nomad-server-1
+    port: 4646
+  difficulty: basic
+  timelimit: 300
+- slug: deploy-the-jobs
+  id: tglnvylrrmeo
+  type: challenge
+  title: Deploy the Chat and MongoDB Jobs
+  teaser: |
+    Deploy the initial versions of the Chat and MongoDB jobs.
+  assignment: |-
+    In this challenge, you will deploy the inital versions of the Chat and MongoDB jobs.
+
+    Inspect the "mongodb.nomad" job specification file on the "Jobs" tab. This will deploy a "db" task group that runs the MongoDB database on port 27017 from the "mongo" Docker image.
+
+    Note that the database persists its data to the Nomad volume "mongodb_vol" which uses the "mongodb_mount" host volume that was configured on each Nomad client. The "mongodb_vol" volume is mounted inside the Docker container on the path "/data/db".
+
+    Navigate to the /root/nomad/jobs directory on the "Server" tab with this command:
+    ```
+    cd /root/nomad/jobs
+    ```
+
+    Run the "mongodb.nomad" job with this command on the "Server" tab:
+    ```
+    nomad job run mongodb.nomad
+    ```
+    This should return something like this:<br>
+    `
+    ==> Monitoring evaluation "d66b5ced"
+    Evaluation triggered by job "mongodb"
+    Evaluation within deployment: "d5d97844"
+    Allocation "3c257515" created: node "8a0ecd90", group "db"
+    Evaluation status changed: "pending" -> "complete"
+    ==> Evaluation "d66b5ced" finished with status "complete"
+    `<br>
+
+    You can check the job in the Nomad UI after waiting 15-30 seconds, clicking the Instruqt refresh button above the Nomad UI, and then selecting the "mongodb" job. You might need to make your browser window a bit wider to see the UI properly and so that the Instruqt buttons do not overlap the Nomad UI tab. You could also click the rectangular button next to the refresh button to hide this assignment. After no more than 1 minute, you should see that the job has 1 healthy allocation.
+
+    Alternatively, you can run the `nomad job status mongodb` command on the "Server" tab to check the status of the job and validate that the "db" task group is healthy.
+
+    Next, inspect the "chatapp.nomad" job specification file on the "Jobs" tab. This job deploys 3 instances of a "chat-app" task group that runs a custom Docker image, "lhaig/anon-app:0.02" created by two HashiCorp solutions engineers, Guy Barrows and Lance Haig. Note that the job specifies the "0.02" tag. Later, when we update the app in various ways, we will specify a different tag to use a different version of it.
+
+    The "chat-app" task group runs on the static port 9002 on the Nomad clients; that port is mapped to port 5000 inside the Docker containers.
+
+    Additionally, the task group has the following stanza:<br>
+    `
+    update {
+      max_parallel     = 1
+      health_check     = "task_states"
+      min_healthy_time = "15s"
+      healthy_deadline = "2m"
+    }
+    `<br>
+
+    This tells Nomad that it should update one instance of the task group at a time, base the health of each instance on the state of its tasks, require a new allocation to be healthy for 15 seconds before marking it as healthy, and require a new allocation to be healthy after no more than 2 minutes; if an allocation is not healthy within 2 minutes, it will be marked as unhealthy.
+
+    Finally, the "chat-app" task group uses Consul Connect [sidecar proxies](https://www.consul.io/docs/connect/proxies.html) to talk to the MongoDB database using mutual Transport Layer Security (mTLS) certificates. This is implemented by this stanza:<br>
+    `
+    connect {
+      sidecar_service {
+        tags = ["chat-app-proxy"]
+        proxy {
+          upstreams {
+            destination_name = "mongodb"
+            local_bind_port = 27017
+          }
+        }
+      }
+    } # end connnect
+    `<br>
+
+    Run the "chatapp.nomad" job on the "Server" tab with this command:
+    ```
+    nomad job run chatapp.nomad
+    ```
+    This should return something like this:<br>
+    `
+    ==> Monitoring evaluation "83924539"
+    Evaluation triggered by job "chat-app"
+    Evaluation within deployment: "e7cde396"
+    Allocation "5fa9f018" created: node "48f9e81c", group "chat-app"
+    Allocation "712e8d99" created: node "8a0ecd90", group "chat-app"
+    Allocation "c81e3ab3" created: node "acba5ef2", group "chat-app"
+    Evaluation status changed: "pending" -> "complete"
+    ==> Evaluation "83924539" finished with status "complete" "complete"
+    `<br>
+
+    After waiting about 30 seconds, check the status of the "chat-app" job with this command on the "Server" tab:
+    ```
+    nomad job status chat-app
+    ```
+
+    This should indicate that the job is running and have an Allocations section at the bottom that looks like this:<br>
+    `
+    Allocations
+    ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
+    8b883f54  8a0ecd90  chat-app    0        run      running  21s ago  18s ago
+    c9cc1c1c  acba5ef2  chat-app    0        run      running  21s ago  14s ago
+    ca660509  48f9e81c  chat-app    0        run      running  21s ago  14s ago
+    `<br>
+
+    Note that the Node IDs of the 3 allocations are all different. In other words, Nomad scheduled one instance of the chat-app task to each Nomad client. It had to do this because we used the static port 9002 which would prevent more than one instance of the app running on any of the Nomad clients.
+
+    You can also check out the "chat-app" job in the Nomad UI. Within 1 minute of running the job, all 3 allocations should be healthy.
+
+    You can also verify that the Nomad task groups were automatically regis†ered as Consul services by looking at the "Services" tab of the Consul UI. Note the sidecar proxy services created by Nomad's integration with Consul Connect.
+
+    You can visit the chat-app UI on the "Chat 1", "Chat 2", and "Chat 3" tabs. You can send messages and then see them show up inside the chat-app UI on the other Chat tabs, but only after selecting those tabs and clicking the Instruqt refresh button.
+
+    In the next challenge, you will update the Chat app using the rolling update strategy.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will deploy the inital versions of the Chat and MongoDB jobs.
+
+      In the next challenge, you will update the Chat app using the rolling update strategy.
+  tabs:
+  - title: Jobs
+    type: code
+    hostname: nomad-server-1
+    path: /root/nomad/jobs/
+  - title: Server
+    type: terminal
+    hostname: nomad-server-1
+  - title: Consul UI
+    type: service
+    hostname: nomad-server-1
+    port: 8500
+  - title: Nomad UI
+    type: service
+    hostname: nomad-server-1
+    port: 4646
+  - title: Fabio UI
+    type: service
+    hostname: nomad-client-1
+    port: 9998
+  - title: Chat 1
+    type: service
+    hostname: nomad-client-1
+    port: 9002
+  - title: Chat 2
+    type: service
+    hostname: nomad-client-2
+    port: 9002
+  - title: Chat 3
+    type: service
+    hostname: nomad-client-3
+    port: 9002
+  difficulty: basic
+  timelimit: 600
+- slug: rolling-update
+  id: 2vakukxvlho2
+  type: challenge
+  title: Do a Rolling Update of the Chat Job
+  teaser: |
+    Do a rolling update of the Chat job.
+  assignment: |-
+    In this challenge, you will do a rolling update of the Chat job.
+
+    Please navigate back to the /root/nomad/jobs directory on the "Server" tab again with this command:
+    ```
+    cd /root/nomad/jobs
+    ```
+
+    Next, you need to modify the "chat-app.nomad" job specification to use a different tag on the "lhaig/anon-app" image. Edit the file on the "Jobs" tab and change the "0.02" tag to "dark-0.02". Then click the disk icon above the file to save it.
+
+    If you prefer, you could just run this command instead of editing the file yourself:
+    ```
+    sed -i "s/anon-app:0.02/anon-app:dark-0.02/g" chatapp.nomad
+    ```
+
+    Now, check what would happen if you redeployed the application with this command:
+    ```
+    nomad job plan chatapp.nomad
+    ```
+
+    This should return the following text:<br>
+    `
+    +/- Job: "chat-app"
+    +/- Task Group: "chat-app" (1 create/destroy update, 2 ignore)
+      +/- Task: "chat-app" (forces create/destroy update)
+        +/- Config {
+          +/- image: "lhaig/anon-app:0.02" => "lhaig/anon-app:dark-0.02"
+            }
+          Task: "connect-proxy-chat-app"
+    `<br>
+    This indicates that Nomad would initially only update 1 of the 3 allocations, confirming that it would do a rolling update.
+
+    Go ahead and actually run a rolling update of the chat-app application:
+    ```
+    nomad job run chatapp.nomad
+    ```
+
+    In the Nomad UI, if you click the Instruqt refresh button and then select the "chat-app" job, you will see that there is a new deployment running. Over the next few minutes, you will see the numbers of placed and healthy allocations for this deployment increase to 3.
+
+    Alternatively, you could monitor the progress of the rolling update by periodically running `nomad deployment status <deployment_id>` where <deployment_id\> is the ID of the latest deployment shown in the Nomad UI.
+
+    As the number of healthy allocations increases, refresh the "Chat 1", "Chat 2", and "Chat 3" tabs to see what happens. The apps should change from a light to a dark background one at a time as the rolling update proceeds. The color of the "Send" button in the app will change from green to purple. Note that the order in which the apps are updated can vary.
+
+    If you happen to catch one of the apps while it is being redeployed, you will see a "Connecting to the service..." message. That is ok.
+
+    Since the chat messages are stored in the MongoDB database, the messages you previously sent will still show up.
+
+    After all the chat-app allocations are healthy and the chat-app clients have the dark background, run the following command on the "Server" tab:
+    ```
+    nomad job status chat-app
+    ```
+    You will now see 6 allocations, 3 of which are marked "complete" while 3 are "running".
+
+    In the next challenge, you will update the Chat app using a blue/green deployment strategy.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will do a rolling update of the Chat job.
+
+      In the next challenge, you will update the Chat app using a blue/green deployment strategy.
+  tabs:
+  - title: Jobs
+    type: code
+    hostname: nomad-server-1
+    path: /root/nomad/jobs/
+  - title: Server
+    type: terminal
+    hostname: nomad-server-1
+  - title: Consul UI
+    type: service
+    hostname: nomad-server-1
+    port: 8500
+  - title: Nomad UI
+    type: service
+    hostname: nomad-server-1
+    port: 4646
+  - title: Fabio UI
+    type: service
+    hostname: nomad-client-1
+    port: 9998
+  - title: Chat 1
+    type: service
+    hostname: nomad-client-1
+    port: 9002
+  - title: Chat 2
+    type: service
+    hostname: nomad-client-2
+    port: 9002
+  - title: Chat 3
+    type: service
+    hostname: nomad-client-3
+    port: 9002
+  difficulty: basic
+  timelimit: 3600
+- slug: blue-green-deployment
+  id: 2o5tzi8hyd5f
+  type: challenge
+  title: Do a Blue/Green Deployment of the Chat Job
+  teaser: |
+    Do a blue/green deployment of the Chat job.
+  assignment: |-
+    In this challenge, you will do a blue/green deployment of the Chat job.
+
+    Please navigate back to the /root/nomad/jobs directory on the "Server" tab again with this command:
+    ```
+    cd /root/nomad/jobs
+    ```
+
+    Edit the "chat-app.nomad" job specification file on the "Jobs" tab, making the following changes:
+
+      1. Change the "dark-0.02" tag on the image back to "0.02".
+      2.
+
+    In the next challenge, you will update the Chat job using a canary deployment.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will do a blue/green deployment of the Chat job.
+
+      In the next challenge, you will update the Chat job using a canary deployment.
+  tabs:
+  - title: Jobs
+    type: code
+    hostname: nomad-server-1
+    path: /root/nomad/jobs/
+  - title: Server
+    type: terminal
+    hostname: nomad-server-1
+  - title: Consul UI
+    type: service
+    hostname: nomad-server-1
+    port: 8500
+  - title: Nomad UI
+    type: service
+    hostname: nomad-server-1
+    port: 4646
+  - title: Fabio UI
+    type: service
+    hostname: nomad-client-1
+    port: 9998
+  - title: Chat 1
+    type: service
+    hostname: nomad-client-1
+    port: 9002
+  - title: Chat 2
+    type: service
+    hostname: nomad-client-2
+    port: 9002
+  - title: Chat 3
+    type: service
+    hostname: nomad-client-3
+    port: 9002
+  difficulty: basic
+  timelimit: 3600
+- slug: canary-deployment
+  id: 8sbd1wqgtqir
+  type: challenge
+  title: Do a Canary Deployment of the Chat Job
+  teaser: |
+    Do a canary deployment of the Chat job.
+  assignment: |-
+    In this challenge, you will do a canary deployment of the Chat job.
+
+    Congratulations on completing the Nomad Job Update Strategies track!
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will do a canary deployment of the Chat job.
+
+      In a canary deployment, one or more additional allocations of the job are deployed while Nomad continues to run the original allocations. This gives operators a chance to verify that the new version of the job is behaving correctly before completely replacing the old version.
+  tabs:
+  - title: Jobs
+    type: code
+    hostname: nomad-server-1
+    path: /root/nomad/jobs/
+  - title: Server
+    type: terminal
+    hostname: nomad-server-1
+  - title: Consul UI
+    type: service
+    hostname: nomad-server-1
+    port: 8500
+  - title: Nomad UI
+    type: service
+    hostname: nomad-server-1
+    port: 4646
+  - title: Fabio UI
+    type: service
+    hostname: nomad-client-1
+    port: 9998
+  - title: Chat 1
+    type: service
+    hostname: nomad-client-1
+    port: 9002
+  - title: Chat 2
+    type: service
+    hostname: nomad-client-2
+    port: 9002
+  - title: Chat 3
+    type: service
+    hostname: nomad-client-3
+    port: 9002
+  difficulty: basic
+  timelimit: 3600
+checksum: "13723511898125120825"

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/check-nomad-server-1
@@ -1,0 +1,29 @@
+#!/bin/bash -l
+
+set -e
+
+grep -q "consul members" /root/.bash_history || fail-message "You have not run 'consul members' on the Server yet."
+
+grep -q "nomad server members" /root/.bash_history || fail-message "You have not run 'nomad server members' on the Server yet."
+
+grep -q "nomad node status" /root/.bash_history || fail-message "You have not run 'nomad node status' on the Server yet."
+
+consul_clients=$(consul members | grep alive | wc -l)
+if [ $consul_clients -ne 4 ]; then
+  echo "There are not 4 running Consul clients."
+  exit 1
+fi
+
+nomad_servers=$(nomad server members | grep alive | wc -l)
+if [ $nomad_servers -ne 1 ]; then
+  echo "The Nomad servers is not running."
+  exit 1
+fi
+
+nomad_clients=$(nomad node status | grep ready | wc -l)
+if [ $nomad_clients -ne 3 ]; then
+  echo "There are not 3 running Nomad clients."
+  exit 1
+fi
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-1
@@ -35,7 +35,7 @@ cat <<-EOF > /etc/consul.d/consul-client1.json
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "0.0.0.0",
   "retry_join": [
     "nomad-server-1"
   ],

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-1
@@ -1,0 +1,67 @@
+#!/bin/bash -l
+
+# Make directory for mongodb mount
+mkdir -p /opt/mongodb/data
+
+# Write Nomad Client 1 Config
+cat <<-EOF > /etc/nomad.d/nomad-client1.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client1"
+
+# Give the agent a unique name.
+name = "client1"
+
+# Enable the client
+client {
+  enabled = true
+
+  host_volume "mongodb_mount" {
+    path      = "/opt/mongodb/data"
+    read_only = false
+  }
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-1:8500"
+}
+EOF
+
+# Write Consul Client 1 Config
+cat <<-EOF > /etc/consul.d/consul-client1.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client1",
+  "node_name": "client1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  },
+  "ports": {
+    "grpc": 8502
+  }
+}
+EOF
+
+# Install CNI plugins
+curl -s -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.3/cni-plugins-linux-amd64-v0.8.3.tgz
+mkdir -p /opt/cni/bin
+tar -C /opt/cni/bin -xzf cni-plugins.tgz
+
+# Configure iptables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
+
+systemctl start consul
+
+sleep 15
+
+systemctl start nomad
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-2
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-2
@@ -35,7 +35,7 @@ cat <<-EOF > /etc/consul.d/consul-client2.json
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "0.0.0.0",
   "retry_join": [
     "nomad-server-1"
   ],

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-2
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-2
@@ -1,0 +1,67 @@
+#!/bin/bash -l
+
+# Make directory for mongodb mount
+mkdir -p /opt/mongodb/data
+
+# Write Nomad Client 2 Config
+cat <<-EOF > /etc/nomad.d/nomad-client2.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client2"
+
+# Give the agent a unique name
+name = "client2"
+
+# Enable the client
+client {
+  enabled = true
+
+  host_volume "mongodb_mount" {
+    path      = "/opt/mongodb/data"
+    read_only = false
+  }
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-2:8500"
+}
+EOF
+
+# Write Consul Client 2 Config
+cat <<-EOF > /etc/consul.d/consul-client2.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client2",
+  "node_name": "client2",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  },
+  "ports": {
+    "grpc": 8502
+  }
+}
+EOF
+
+# Install CNI plugins
+curl -s -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.3/cni-plugins-linux-amd64-v0.8.3.tgz
+mkdir -p /opt/cni/bin
+tar -C /opt/cni/bin -xzf cni-plugins.tgz
+
+# Configure iptables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
+
+systemctl start consul
+
+sleep 15
+
+systemctl start nomad
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-3
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-3
@@ -1,0 +1,67 @@
+#!/bin/bash -l
+
+# Make directory for mongodb mount
+mkdir -p /opt/mongodb/data
+
+# Write Nomad Client 3 Config
+cat <<-EOF > /etc/nomad.d/nomad-client3.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client3"
+
+# Give the agent a unique name
+name = "client3"
+
+# Enable the client
+client {
+  enabled = true
+
+  host_volume "mongodb_mount" {
+    path      = "/opt/mongodb/data"
+    read_only = false
+  }
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-3:8500"
+}
+EOF
+
+# Write Consul Client 3 Config
+cat <<-EOF > /etc/consul.d/consul-client3.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client3",
+  "node_name": "client3",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  },
+  "ports": {
+    "grpc": 8502
+  }
+}
+EOF
+
+# Install CNI plugins
+curl -s -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.3/cni-plugins-linux-amd64-v0.8.3.tgz
+mkdir -p /opt/cni/bin
+tar -C /opt/cni/bin -xzf cni-plugins.tgz
+
+# Configure iptables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
+
+systemctl start consul
+
+sleep 15
+
+systemctl start nomad
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-3
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-client-3
@@ -35,7 +35,7 @@ cat <<-EOF > /etc/consul.d/consul-client3.json
   "data_dir": "/tmp/consul/client3",
   "node_name": "client3",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "0.0.0.0",
   "retry_join": [
     "nomad-server-1"
   ],

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-server-1
@@ -51,7 +51,7 @@ cat <<-EOF > /etc/consul.d/consul-server1.json
   "data_dir": "/tmp/consul/server1",
   "node_name": "server1",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "0.0.0.0",
   "bootstrap_expect": 1,
   "connect": {
     "enabled": true
@@ -71,7 +71,7 @@ cat <<-EOF > /root/nomad/consul-server1.json
   "data_dir": "/tmp/consul/server1",
   "node_name": "server1",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "0.0.0.0",
   "bootstrap_expect": 1,
   "connect": {
     "enabled": true
@@ -114,7 +114,7 @@ cat <<-EOF > /root/nomad/consul-client1.json
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "0.0.0.0",
   "retry_join": [
     "nomad-server-1"
   ],
@@ -159,7 +159,7 @@ cat <<-EOF > /root/nomad/consul-client2.json
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "0.0.0.0",
   "retry_join": [
     "nomad-server-1"
   ],
@@ -204,7 +204,7 @@ cat <<-EOF > /root/nomad/consul-client3.json
   "data_dir": "/tmp/consul/client3",
   "node_name": "client3",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "0.0.0.0",
   "retry_join": [
     "nomad-server-1"
   ],

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/setup-nomad-server-1
@@ -1,0 +1,238 @@
+#!/bin/bash -l
+
+mkdir /root/nomad
+
+# Write Nomad Server 1 Config
+cat <<-EOF > /etc/nomad.d/nomad-server1.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/server1"
+
+# Give the agent a unique name.
+name = "server1"
+
+# Enable the server
+server {
+  enabled = true
+  bootstrap_expect = 1
+}
+
+# Consul configuration
+consul {
+  address = "nomad-server-1:8500"
+}
+EOF
+
+# Write Copy of Nomad Server 1 Config
+cat <<-EOF > /root/nomad/nomad-server1.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/server1"
+
+# Give the agent a unique name.
+name = "server1"
+
+# Enable the server
+server {
+  enabled = true
+  bootstrap_expect = 1
+}
+
+# Consul configuration
+consul {
+  address = "nomad-server-1:8500"
+}
+EOF
+
+# Write Consul Server 1 Config
+cat <<-EOF > /etc/consul.d/consul-server1.json
+{
+  "server": true,
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/server1",
+  "node_name": "server1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "bootstrap_expect": 1,
+  "connect": {
+    "enabled": true
+  },
+  "ports": {
+    "grpc": 8502
+  }
+}
+EOF
+
+# Write Copy of Consul Server 1 Config
+cat <<-EOF > /root/nomad/consul-server1.json
+{
+  "server": true,
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/server1",
+  "node_name": "server1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "bootstrap_expect": 1,
+  "connect": {
+    "enabled": true
+  },
+  "ports": {
+    "grpc": 8502
+  }
+}
+EOF
+
+# Write Nomad Client 1 Config
+cat <<-EOF > /root/nomad/nomad-client1.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client1"
+
+# Give the agent a unique name.
+name = "client1"
+
+# Enable the client
+client {
+  enabled = true
+
+  host_volume "mongodb_mount" {
+    path      = "/opt/mongodb/data"
+    read_only = false
+  }
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-1:8500"
+}
+EOF
+
+# Write Consul Client 1 Config
+cat <<-EOF > /root/nomad/consul-client1.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client1",
+  "node_name": "client1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  },
+  "ports": {
+    "grpc": 8502
+  }
+}
+EOF
+
+# Write Nomad Client 2 Config
+cat <<-EOF > /root/nomad/nomad-client2.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client2"
+
+# Give the agent a unique name.
+name = "client2"
+
+# Enable the client
+client {
+  enabled = true
+
+  host_volume "mongodb_mount" {
+    path      = "/opt/mongodb/data"
+    read_only = false
+  }
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-2:8500"
+}
+EOF
+
+# Write Consul Client 2 Config
+cat <<-EOF > /root/nomad/consul-client2.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client2",
+  "node_name": "client2",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  },
+  "ports": {
+    "grpc": 8502
+  }
+}
+EOF
+
+# Write Nomad Client 3 Config
+cat <<-EOF > /root/nomad/nomad-client3.hcl
+# Setup data dir
+data_dir = "/tmp/nomad/client3"
+
+# Give the agent a unique name.
+name = "client3"
+
+# Enable the client
+client {
+  enabled = true
+
+  host_volume "mongodb_mount" {
+    path      = "/opt/mongodb/data"
+    read_only = false
+  }
+}
+
+# Consul configuration
+consul {
+  address = "nomad-client-3:8500"
+}
+EOF
+
+# Write Consul Client 3 Config
+cat <<-EOF > /root/nomad/consul-client3.json
+{
+  "ui": true,
+  "log_level": "INFO",
+  "data_dir": "/tmp/consul/client3",
+  "node_name": "client3",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
+  "retry_join": [
+    "nomad-server-1"
+  ],
+  "connect": {
+    "enabled": true
+  },
+  "ports": {
+    "grpc": 8502
+  }
+}
+EOF
+
+# Install CNI plugins
+curl -s -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.3/cni-plugins-linux-amd64-v0.8.3.tgz
+mkdir -p /opt/cni/bin
+tar -C /opt/cni/bin -xzf cni-plugins.tgz
+
+# Configure iptables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
+echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
+
+systemctl start consul
+
+sleep 15
+
+systemctl start nomad
+
+sleep 30
+
+exit 0

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/solve-nomad-server-1
@@ -1,0 +1,16 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+# Run consul members
+consul members
+
+# Run nomad server members
+nomad server members
+
+# Run nomad node status
+nomad node status
+
+exit 0


### PR DESCRIPTION
Added track https://play.instruqt.com/hashicorp/tracks/nomad-update-strategies that implements https://learn.hashicorp.com/nomad/update-strategies.  It uses the chat-app appliction from Guy Barrows and Lance Haig: https://github.com/GuyBarros/anonymouse-realtime-chat-app with docker images in https://hub.docker.com/r/lhaig/anon-app.

This version uses Fabio, but it does not seem compatible with the sockets.io library that the app uses.  I will try using nginx instead of Fabio in a different branch. 