### PR TITLE
update to Nomad 0.10.4, Consul 1.7.1

### DIFF
--- a/instruqt-tracks/nomad-integration-with-vault/config.yml
+++ b/instruqt-tracks/nomad-integration-with-vault/config.yml
@@ -1,21 +1,21 @@
 version: "2"
 virtualmachines:
 - name: hashistack-server
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-5-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-server:8500
     VAULT_ADDR: http://127.0.0.1:8200/
   machine_type: n1-standard-1
 - name: hashistack-client-1
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-5-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-client-1:8500
     VAULT_ADDR: http://active.vault.service.consul:8200/
   machine_type: n1-standard-1
 - name: hashistack-client-2
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-5-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-client-2:8500

--- a/instruqt-tracks/nomad-integration-with-vault/track.yml
+++ b/instruqt-tracks/nomad-integration-with-vault/track.yml
@@ -332,7 +332,7 @@ challenges:
     ```
     nomad status database
     ```
-    You should see a summary of the database job that shows its status as "running". If it is not running, wait 15 seconds and re-run the command. You can also explore the job details in the Nomad UI on the "Nomad" tab.
+    You should see a summary of the database job that shows its status as "running". If it is not running, wait 15 seconds and re-run the command. Eventually, the "db" task group should have 1 healthy allocation. You can also explore the job details in the Nomad UI on the "Nomad" tab.
 
     Our next challenge will be to configure the Vault Database Secrets Engine.
 
@@ -496,7 +496,7 @@ challenges:
     ```
     nomad run /root/hashistack/nomad/web.nomad
     ```
-    Click on the "Nomad" tab and wait until the job has been successfully deployed in the Nomad UI as indicated by a green bar in the Summary column for the "web" job in the list of jobs. Alternatively, you can run the `nomad status web` command until it shows the status of the web job as "running".
+    Click on the "Nomad" tab and wait until the job has been successfully deployed in the Nomad UI as indicated by a green bar in the Summary column for the "web" job in the list of jobs. Alternatively, you can run the `nomad status web` command until it shows the status of the web job as "running" and the "demo" task group has 1 healthy allocation.
 
     After waiting about 30 seconds, confirm that the application is accessing the database by running two commands on the "Server" tab.
 
@@ -579,4 +579,4 @@ challenges:
     port: 3000
   difficulty: basic
   timelimit: 600
-checksum: "6434272770393878953"
+checksum: "3842454214146841892"


### PR DESCRIPTION
This now uses the GCP image instruqt-hashicorp/hashistack-0-5-1 which uses Nomad 0.10.4, Consul 1.7.1, and Nomad 1.3.2.  I updated this to test fix to Consul 1.7 (in 1.7.1) which had prevented consul services from displaying in the Consul UI if Consul Connect was not enabled on all the Consul clients.  The fix did work.  Having this track on newer version of Nomad and Consul is fringe benefit.  It had been using Nomad 0.10.2, Consul 1.6.2, and Vault 1.3.0

I also expanded descriptions of what to look for in `nomad status` commands in track.yml to include verifying that each job has 1 healthy allocation.