### PR TITLE
create separate nomad-consul-connect track

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,46 @@ jobs:
               echo "Instruqt track test failed three times."
               exit 1
             fi
+  instruqt-test-nomad-consul-connect:
+    docker:
+      - image: ubuntu:latest
+    steps:
+      - checkout
+      - run:
+          name: Run Instruqt Test
+          command: |
+            VERSION=$INSTRUQT_VERSION
+            apt -y update
+            apt -y install wget unzip
+            wget https://github.com/instruqt/cli/releases/download/${VERSION}/instruqt-linux-${VERSION}.zip -O /tmp/instruqt.zip
+            cd /tmp
+            unzip instruqt.zip
+            cp instruqt /usr/local/bin/instruqt
+            chmod +x /usr/local/bin/instruqt
+            echo "yes" | instruqt version
+            RETVAL=$?
+            if [[ $RETVAL -ne 0 ]]; then
+              echo "Instruqt is not installed correctly."
+              exit 1
+            else
+              echo "Instruqt is installed and updated to most recent version."
+            fi
+            cd /root/project/instruqt-tracks/nomad-consul-connect
+            echo "Running instruqt track push..."
+            instruqt track push --force
+            echo "Running instruqt track test..."
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 60
+            done
+            if [ $n -ge 3 ]; then
+              echo "Instruqt track test failed three times."
+              exit 1
+            fi
   instruqt-test-nomad-acls:
     docker:
       - image: ubuntu:latest
@@ -494,6 +534,12 @@ workflows:
           filters:
             branches:
               only: master
+      - instruqt-test-nomad-consul-connect:
+          requires:
+            - instruqt-validate
+          filters:
+            branches:
+              only: master
       - instruqt-test-nomad-acls:
           requires:
             - instruqt-validate
@@ -559,6 +605,9 @@ workflows:
           requires:
             - instruqt-validate
       - instruqt-test-nomad-multi-server-cluster:
+          requires:
+            - instruqt-validate
+      - instruqt-test-nomad-consul-connect:
           requires:
             - instruqt-validate
       - instruqt-test-nomad-acls:

--- a/instruqt-tracks/nomad-and-portworx/install-portworx/setup-cloud-client
+++ b/instruqt-tracks/nomad-and-portworx/install-portworx/setup-cloud-client
@@ -105,7 +105,7 @@ job "portworx" {
 }
 EOF
 
-# SCP portworx.noamd to Nomad Server
+# SCP portworx.nomad to Nomad Server
 gcloud compute scp /root/nomad/portworx.nomad nomad-server-1:/root/nomad/portworx.nomad --strict-host-key-checking no --zone "europe-west1-b"
 
 exit 0

--- a/instruqt-tracks/nomad-and-portworx/track.yml
+++ b/instruqt-tracks/nomad-and-portworx/track.yml
@@ -436,4 +436,4 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 600
-checksum: "3638753123550114650"
+checksum: "5029093659160743354"

--- a/instruqt-tracks/nomad-and-portworx/verify-nomad-cluster-health/setup-cloud-client
+++ b/instruqt-tracks/nomad-and-portworx/verify-nomad-cluster-health/setup-cloud-client
@@ -30,7 +30,7 @@ gcloud compute firewall-rules create nomad-allow-inbound-serf --allow tcp:4648 -
 # Create /root/nomad on Cloud Client
 mkdir /root/nomad
 
-# Create /root/noamd on Nomad Server
+# Create /root/nomad on Nomad Server
 gcloud compute ssh nomad-server-1 --zone europe-west1-b  --project $INSTRUQT_GCP_PROJECT_NOMAD_PROJECT_ID --strict-host-key-checking no --command "mkdir /root/nomad"
 
 ### Consul Server 1 ###

--- a/instruqt-tracks/nomad-consul-connect/config.yml
+++ b/instruqt-tracks/nomad-consul-connect/config.yml
@@ -1,0 +1,20 @@
+version: "2"
+virtualmachines:
+- name: nomad-server-1
+  image: instruqt-hashicorp/hashistack-0-6-1
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-server-1:8500
+  machine_type: n1-standard-1
+- name: nomad-client-1
+  image: instruqt-hashicorp/hashistack-0-6-1
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-client-1:8500
+  machine_type: n1-standard-1
+- name: nomad-client-2
+  image: instruqt-hashicorp/hashistack-0-6-1
+  shell: /bin/bash -l
+  environment:
+    CONSUL_HTTP_ADDR: nomad-client-2:8500
+  machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-consul-connect/nomad-and-consul-connect/check-nomad-server-1
+++ b/instruqt-tracks/nomad-consul-connect/nomad-and-consul-connect/check-nomad-server-1
@@ -1,0 +1,12 @@
+#!/bin/bash -l
+
+set -e
+
+grep -q "nomad job run connect.nomad" /root/.bash_history || fail-message "You haven't run the connect.nomad job yet."
+
+nomad_allocations=$(nomad job status countdash | grep Healthy -A3 | grep "1        1       1" | wc -l)
+if [ $nomad_allocations -ne 2 ]; then
+  fail-message "The countdash job does not have 2 healthy allocations."
+fi
+
+exit 0

--- a/instruqt-tracks/nomad-consul-connect/nomad-and-consul-connect/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-consul-connect/nomad-and-consul-connect/setup-nomad-server-1
@@ -1,0 +1,72 @@
+#!/bin/bash -l
+
+# Write connect.nomad to /root/nomad/connect.nomad
+cat <<-EOF > /root/nomad/connect.nomad
+job "countdash" {
+  datacenters = ["dc1"]
+
+  group "api" {
+    network {
+      mode = "bridge"
+    }
+
+    service {
+      name = "count-api"
+      port = "9001"
+
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    task "web" {
+      driver = "docker"
+
+      config {
+        image = "hashicorpnomad/counter-api:v1"
+      }
+    }
+  }
+
+  group "dashboard" {
+    network {
+      mode = "bridge"
+
+      port "http" {
+        static = 9002
+        to     = 9002
+      }
+    }
+
+    service {
+      name = "count-dashboard"
+      port = "9002"
+
+      connect {
+        sidecar_service {
+          proxy {
+            upstreams {
+              destination_name = "count-api"
+              local_bind_port  = 8080
+            }
+          }
+        }
+      }
+    }
+
+    task "dashboard" {
+      driver = "docker"
+
+      env {
+        COUNTING_SERVICE_URL = "http://\${NOMAD_UPSTREAM_ADDR_count_api}"
+      }
+
+      config {
+        image = "hashicorpnomad/counter-dashboard:v1"
+      }
+    }
+  }
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/nomad-consul-connect/nomad-and-consul-connect/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-consul-connect/nomad-and-consul-connect/solve-nomad-server-1
@@ -1,0 +1,13 @@
+#!/bin/bash -l
+
+# Navigate to /root/nomad directory
+cd nomad
+
+# Run the connect.nomad Job
+echo -e "nomad job run connect.nomad" >> /root/.bash_history
+nomad job run connect.nomad
+
+# Sleep
+sleep 60
+
+exit 0

--- a/instruqt-tracks/nomad-consul-connect/track.yml
+++ b/instruqt-tracks/nomad-consul-connect/track.yml
@@ -1,0 +1,158 @@
+slug: nomad-consul-connect
+id: juyvie8yv7ky
+type: track
+title: Nomad Integration with Consul Connect
+teaser: |
+  Learn how to run Nomad jobs secured by Consul Connect.
+description: |-
+  This track will show you how easy it is to register Nomad tasks as Consul services so that they can talk to each other using Consul's service discovery and how you can use Nomad's integration with [Consul Connect](https://www.nomadproject.io/docs/integrations/consul-connect/) to secure the communications between the services.
+
+  Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics) and [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster) tracks.
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
+tags:
+- nomad
+- consul
+- consul connect
+owner: hashicorp
+developers:
+- roger@hashicorp.com
+private: false
+published: true
+challenges:
+- slug: verify-nomad-cluster-health
+  id: y96veofixdxn
+  type: challenge
+  title: Verify the Health of Your Nomad Cluster
+  teaser: |
+    Verify the health of the Nomad cluster that has been deployed for you.
+  assignment: |-
+    In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
+
+    The cluster is running 1 Nomad/Consul server and 2 Nomad/Consul clients. They are using Nomad 0.11.1 and Consul 1.7.2.
+
+    First, verify that all 3 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
+    ```
+    consul members
+    ```
+    You should see 3 Consul agents with the "alive" status.
+
+    Check that the Nomad server is running by running this command on the "Server" tab:
+    ```
+    nomad server members
+    ```
+    You should see 1 Nomad server with the "alive" status.
+
+    Check the status of the Nomad client nodes by running this command on the "Server" tab:
+    ```
+    nomad node status
+    ```
+    You should see 2 Nomad clients with the "ready" status.
+
+    You can also check the status of the Nomad server and clients in the Nomad and Consul UIs.
+
+    In the next challenge, you will run jobs that deploy a web application and the Traefik load balancer.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts.
+
+      This will include checking the health of a Consul cluster that has been set up on the same VMs.
+  tabs:
+  - title: Server
+    type: terminal
+    hostname: nomad-server-1
+  - title: Consul UI
+    type: service
+    hostname: nomad-server-1
+    port: 8500
+  - title: Nomad UI
+    type: service
+    hostname: nomad-server-1
+    port: 4646
+  difficulty: basic
+  timelimit: 300
+- slug: nomad-and-consul-connect
+  id: qtu9dyfttayl
+  type: challenge
+  title: Nomad's Integration with Consul Connect
+  teaser: |
+    Run a Nomad job with tasks that communicate securely using Consul Connect.
+  assignment: |-
+    In this challenge, you will run a job that uses Nomad's native integrations with Consul and Consul Connect. The job's tasks will use Consul's service registration, service discovery, and secure service-to-service communication (using Consul Connect).
+
+    In order to support Consul Connect, Nomad adds a new networking mode for jobs that enables tasks in the same task group to share their networking stack. When Connect is enabled, Nomad launches an Envoy proxy alongside the application in the job file. The proxy (Envoy) provides secure communication with other applications in the Nomad cluster.
+
+    First, examine the Nomad job specification file, connect.nomad that we have placed in the /root/nomad directory. You can use the code editor on the "Config Files" tab.
+
+    This job specification file defines two task groups:
+      1. The `api` task group runs a counting service API in a container running the `hashicorpnomad/counter-api` Docker image on port 9001 on the bridge network.
+      2. The `dashboard` task group runs a web dashboard  in a container running the `hashicorpnomad/counter-dashboard` Docker image on port 9001 on the bridge network.
+
+    The `api` task group registers itself with Consul as the `count-api` service listening on port 9001. It runs on the bridge network and therefore has an isolated network namespace with an interface bridged to the host it runs on. It does not define any ports in its network because it is only accessible via Consul Connect. The Envoy proxy will automatically route traffic sent to the service using port 9001 to the port inside the network namespace dynamically selected by Nomad.
+
+    The `dashboard` task group registers itself with Consul as the `count-dashboard` service. It runs on the bridge network and uses the static forwarded port, 9002, which asks Nomad to use external port 9002 for the service and to forward requests to the same port inside the task group's own network namespace.
+
+    So, a web browser can connect to the dashboard using `http://<host_ip>:9002`. The dashboard uses Consul Connect to make calls to the api service through a sidecar proxy. The `upstreams` stanza in the `proxy` stanza indicates that the sidecar proxy will listen on port 8080 inside the dashboard task group's network namespace. This means that requests to the dashboard on port 9002 will be forwarded to the sidecar proxy on port 8080.
+
+    The `dashboard` task within the `dashboard` task group uses the `COUNTING_SERVICE_URL` environment variable set to `http://${NOMAD_UPSTREAM_ADDR_count_api}`. This uses Nomad's interpolation to tell the dashboard application inside the Docker container what dynamic IP and port to use to talk to the sidecar proxy.
+
+    Summarizing, Nomad will automatically deploy two Consul Connect proxies to allow the dashboard web application to communicate securely with the count-api service. Consul Connect tells the dashboard proxy how to find the count-api proxy.
+
+    Now, that we've explored the connect.nomad job specification, you can run the job.  Please do this on the "Server 1" tab by running:
+    ```
+    cd nomad
+    nomad job run connect.nomad
+    ```
+    You should see something like this:
+    ```
+    ==> Monitoring evaluation "fdf1c932"
+    Evaluation triggered by job "countdash"
+    Evaluation within deployment: "ab006141"
+    Allocation "8dff276a" created: node "f94fc4ad", group "api"
+    Allocation "f4225a5f" created: node "f94fc4ad", group "dashboard"
+    Evaluation status changed: "pending" -> "complete"
+    ==> Evaluation "fdf1c932" finished with status "complete"
+    ```
+
+    Finally, use the dashboard web application on the "Dashboard 1" or the "Dashboard 2" tab.  We have exposed tabs for both of the Nomad clients because we don't know in advance which client Nomad will schedule the task groups on.
+
+    As you watch the app, you should see the counter climb.
+
+    You can also look at the tasks associated proxies in both the Nomad and the Consul UIs.
+
+    Congratulations on completing the Nomad Integration with Consul Connect track!
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will run a job that uses Nomad's native integration with Consul. The job's tasks will use Consul's service registration, service discovery, and secure service-to-service communication (using Consul Connect).
+
+      This challenge is based on the  Consul Connect](https://www.nomadproject.io/docs/integrations/consul-connect/) in the Nomad documentation.
+
+      There is also a [version](https://learn.hashicorp.com/nomad/consul-integration/nomad-connect-acl) of this guide that can be used with a Consul cluster that has Consul ACLs enabled.
+  tabs:
+  - title: Config Files
+    type: code
+    hostname: nomad-server-1
+    path: /root/nomad/
+  - title: Server 1
+    type: terminal
+    hostname: nomad-server-1
+  - title: Nomad UI
+    type: service
+    hostname: nomad-server-1
+    port: 4646
+  - title: Consul UI
+    type: service
+    hostname: nomad-server-1
+    port: 8500
+  - title: Dashboard-1
+    type: service
+    hostname: nomad-client-1
+    port: 9002
+  - title: Dashboard-2
+    type: service
+    hostname: nomad-client-2
+    port: 9002
+  difficulty: basic
+  timelimit: 1200
+checksum: "4377196957165976845"

--- a/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/check-nomad-server-1
+++ b/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/check-nomad-server-1
@@ -9,21 +9,18 @@ grep -q "nomad server members" /root/.bash_history || fail-message "You have not
 grep -q "nomad node status" /root/.bash_history || fail-message "You have not run 'nomad node status' on the Server yet."
 
 consul_clients=$(consul members | grep alive | wc -l)
-if [ $consul_clients -ne 4 ]; then
-  echo "There are not 4 running Consul clients."
-  exit 1
+if [ $consul_clients -ne 3 ]; then
+  fail-message "There are not 3 running Consul clients."
 fi
 
 nomad_servers=$(nomad server members | grep alive | wc -l)
 if [ $nomad_servers -ne 1 ]; then
-  echo "The Nomad server is not running."
-  exit 1
+  fail-message "The Nomad server is not running."
 fi
 
 nomad_clients=$(nomad node status | grep ready | wc -l)
-if [ $nomad_clients -ne 3 ]; then
-  echo "There are not 3 running Nomad clients."
-  exit 1
+if [ $nomad_clients -ne 2 ]; then
+  fail-message "There are not 2 running Nomad clients."
 fi
 
 exit 0

--- a/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/setup-nomad-client-1
@@ -1,12 +1,12 @@
 #!/bin/bash -l
 
-# Write Nomad Client 2 Config
-cat <<-EOF > /etc/nomad.d/nomad-client2.hcl
+# Write Nomad Client 1 Config
+cat <<-EOF > /etc/nomad.d/nomad-client1.hcl
 # Setup data dir
-data_dir = "/tmp/nomad/client2"
+data_dir = "/tmp/nomad/client1"
 
-# Give the agent a unique name
-name = "client2"
+# Give the agent a unique name.
+name = "client1"
 
 # Enable the client
 client {
@@ -15,18 +15,18 @@ client {
 
 # Consul configuration
 consul {
-  address = "nomad-client-2:8500"
+  address = "nomad-client-1:8500"
 }
 EOF
 
-# Write Consul Client 2 Config
-cat <<-EOF > /etc/consul.d/consul-client2.json
+# Write Consul Client 1 Config
+cat <<-EOF > /etc/consul.d/consul-client1.json
 {
   "ui": true,
   "log_level": "INFO",
-  "data_dir": "/tmp/consul/client2",
-  "node_name": "client2",
-  "bind_addr": "{{ GetInterfaceIP \"ens\" }}",
+  "data_dir": "/tmp/consul/client1",
+  "node_name": "client1",
+  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
   "client_addr": "0.0.0.0",
   "retry_join": [
     "nomad-server-1"
@@ -50,13 +50,10 @@ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
 
-# Start Consul
 systemctl start consul
 
-# Sleep
 sleep 15
 
-# Start Nomad
 systemctl start nomad
 
 exit 0

--- a/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/setup-nomad-client-2
+++ b/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/setup-nomad-client-2
@@ -50,13 +50,10 @@ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
 
-# Start Consul
 systemctl start consul
 
-# Sleep
 sleep 15
 
-# Start Nomad
 systemctl start nomad
 
 exit 0

--- a/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/setup-nomad-server-1
@@ -162,46 +162,6 @@ cat <<-EOF > /root/nomad/consul-client2.json
 }
 EOF
 
-# Write Nomad Client 3 Config
-cat <<-EOF > /root/nomad/nomad-client3.hcl
-# Setup data dir
-data_dir = "/tmp/nomad/client3"
-
-# Give the agent a unique name.
-name = "client3"
-
-# Enable the client
-client {
-  enabled = true
-}
-
-# Consul configuration
-consul {
-  address = "nomad-client-3:8500"
-}
-EOF
-
-# Write Consul Client 3 Config
-cat <<-EOF > /root/nomad/consul-client3.json
-{
-  "ui": true,
-  "log_level": "INFO",
-  "data_dir": "/tmp/consul/client3",
-  "node_name": "client3",
-  "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "0.0.0.0",
-  "retry_join": [
-    "nomad-server-1"
-  ],
-  "connect": {
-    "enabled": true
-  },
-  "ports": {
-    "grpc": 8502
-  }
-}
-EOF
-
 # Install CNI plugins
 curl -s -L -o cni-plugins.tgz https://github.com/containernetworking/plugins/releases/download/v0.8.3/cni-plugins-linux-amd64-v0.8.3.tgz
 mkdir -p /opt/cni/bin
@@ -212,19 +172,14 @@ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
 
-# Start Consul
 systemctl start consul
 
-#update and install dnsutils
+#update and install
 apt update&&apt -y install dnsutils
+#sleep 15
 
-# Sleep
-sleep 15
-
-# Start Nomad
 systemctl start nomad
 
-# Sleep
 sleep 45
 
 exit 0

--- a/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-consul-connect/verify-nomad-cluster-health/solve-nomad-server-1
@@ -1,0 +1,16 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+# Run consul members
+consul members
+
+# Run nomad server members
+nomad server members
+
+# Run nomad node status
+nomad node status
+
+exit 0

--- a/instruqt-tracks/nomad-job-placement/track.yml
+++ b/instruqt-tracks/nomad-job-placement/track.yml
@@ -498,4 +498,4 @@ challenges:
     port: 8080
   difficulty: basic
   timelimit: 600
-checksum: "11263529465167044908"
+checksum: "12968950113535932873"

--- a/instruqt-tracks/nomad-job-placement/track.yml
+++ b/instruqt-tracks/nomad-job-placement/track.yml
@@ -498,4 +498,4 @@ challenges:
     port: 8080
   difficulty: basic
   timelimit: 600
-checksum: "12968950113535932873"
+checksum: "5422492009686792881"

--- a/instruqt-tracks/nomad-job-placement/verify-nomad-cluster-health/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-job-placement/verify-nomad-cluster-health/setup-nomad-client-1
@@ -50,10 +50,13 @@ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
 
+# Start Consul
 systemctl start consul
 
+# Sleep
 sleep 15
 
+# Start Nomad
 systemctl start nomad
 
 exit 0

--- a/instruqt-tracks/nomad-job-placement/verify-nomad-cluster-health/setup-nomad-client-3
+++ b/instruqt-tracks/nomad-job-placement/verify-nomad-cluster-health/setup-nomad-client-3
@@ -50,10 +50,13 @@ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
 echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
 
+# Start Consul
 systemctl start consul
 
+# Sleep
 sleep 15
 
+# Start Nomad
 systemctl start nomad
 
 exit 0

--- a/instruqt-tracks/nomad-job-placement/verify-nomad-cluster-health/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-job-placement/verify-nomad-cluster-health/setup-nomad-server-1
@@ -215,9 +215,6 @@ echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
 # Start Consul
 systemctl start consul
 
-#update and install dnsutils
-apt update&&apt -y install dnsutils
-
 # Sleep
 sleep 15
 

--- a/instruqt-tracks/nomad-multi-server-cluster/track.yml
+++ b/instruqt-tracks/nomad-multi-server-cluster/track.yml
@@ -8,7 +8,7 @@ description: |-
 
   You'll also see how easy it is to register Nomad tasks as Consul services so that they can talk to each other using Consul's service discovery.
 
-  In fact, we'll even use Nomad's integration with [Consul Connect](https://www.nomadproject.io/guides/integrations/consul-connect/index.html) to secure the communications between the services!
+  In fact, we'll even use Nomad's integration with [Consul Connect](https://www.nomadproject.io/docs/integrations/consul-connect/) to secure the communications between the services!
 
   Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics) and [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster) tracks.
 icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
@@ -103,7 +103,7 @@ challenges:
   notes:
   - type: text
     contents: |-
-      This track will show you how to bootstrap a Nomad cluster that has three servers and two clients in two different ways. You will also learn how easy it is to register Nomad tasks as Consul services and secure them with Nomad's native integration with [Consul Connect](https://www.nomadproject.io/guides/integrations/consul-connect/index.html).
+      This track will show you how to bootstrap a Nomad cluster that has three servers and two clients in two different ways. You will also learn how easy it is to register Nomad tasks as Consul services and secure them with Nomad's native integration with [Consul Connect](https://learn.hashicorp.com/nomad/consul-integration/nomad-connect-acl).
 
       In this first challenge, you will bootstrap the Nomad cluster using manual clustering.
 
@@ -360,7 +360,7 @@ challenges:
     contents: |-
       In this challenge, you will run a job that uses Nomad's native integration with Consul. The job's tasks will use Consul's service registration, service discovery, and secure service-to-service communication (using Consul Connect).
 
-      This challenge is based on the [Nomad Consul Connect Example](https://www.nomadproject.io/guides/integrations/consul-connect/index.html) in the Nomad documentation.
+      This challenge is based on the [Nomad Consul Connect Example](https://www.nomadproject.io/docs/integrations/consul-connect/) in the Nomad documentation.
 
       For additional information about Consul Connect, see the [Consul Connect](https://www.consul.io/docs/connect/index.html) documentation.
   tabs:
@@ -401,4 +401,4 @@ challenges:
     port: 9002
   difficulty: basic
   timelimit: 1200
-checksum: "5255244368384016527"
+checksum: "12916979421926795240"

--- a/instruqt-tracks/nomad-update-strategies/track.yml
+++ b/instruqt-tracks/nomad-update-strategies/track.yml
@@ -633,4 +633,4 @@ challenges:
     port: 8080
   difficulty: basic
   timelimit: 600
-checksum: "638890923098356148"
+checksum: "7445511630857102225"

--- a/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/verify-nomad-cluster-health/check-nomad-server-1
@@ -15,7 +15,7 @@ fi
 
 nomad_servers=$(nomad server members | grep alive | wc -l)
 if [ $nomad_servers -ne 1 ]; then
-  fail-message "The Nomad servers is not running."
+  fail-message "The Nomad server is not running."
 fi
 
 nomad_clients=$(nomad node status | grep ready | wc -l)


### PR DESCRIPTION
I split out the Nomad-Consul Connect challenge which is at the end of the nomad-multi-server-cluster track into a new track called nomad-consul-connect.  I left the original challenge in place.

My reason for creating the new track was to make it easier for SEs to demo Nomad integration with Consul Connect since they can now use the new track without having to step through the other two challenges which focused on configuring the Nomad/Consul clusters.

This PR also includes some fixes for typos and extra comments in some scripts.