### PR TITLE
run as user nomad

### DIFF
--- a/instruqt-tracks/nomad-governance/config.yml
+++ b/instruqt-tracks/nomad-governance/config.yml
@@ -1,26 +1,26 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/nomad-ent-0-10-4
-  shell: /bin/bash -l
+  image: instruqt-hashicorp/nomad-ent-0-11-1
+  shell: sudo -u nomad -i /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/nomad-ent-0-10-4
-  shell: /bin/bash -l
+  image: instruqt-hashicorp/nomad-ent-0-11-1
+  shell: sudo -u nomad -i /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/nomad-ent-0-10-4
-  shell: /bin/bash -l
+  image: instruqt-hashicorp/nomad-ent-0-11-1
+  shell: sudo -u nomad -i /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/nomad-ent-0-10-4
-  shell: /bin/bash -l
+  image: instruqt-hashicorp/nomad-ent-0-11-1
+  shell: sudo -u nomad -i /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-3:8500
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-governance/namespaces-and-resource-quotas/check-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/namespaces-and-resource-quotas/check-nomad-server-1
@@ -2,18 +2,18 @@
 
 set -e
 
-grep -q "cd /root/nomad/quotas" /root/.bash_history || fail-message "You have not navigated to the /root/nomad/quotas directory on the Server yet."
+grep -q "cd /home/nomad/nomad/quotas" /home/nomad/.bash_history || fail-message "You have not navigated to the /home/nomad/nomad/quotas directory on the Server yet."
 
-grep -q "nomad quota apply quota-default.hcl" /root/.bash_history || fail-message "You have not created the default resource quota on the Server yet."
+grep -q "nomad quota apply quota-default.hcl" /home/nomad/.bash_history || fail-message "You have not created the default resource quota on the Server yet."
 
-grep -q "nomad quota apply quota-dev.hcl" /root/.bash_history || fail-message "You have not created the dev resource quota on the Server yet."
+grep -q "nomad quota apply quota-dev.hcl" /home/nomad/.bash_history || fail-message "You have not created the dev resource quota on the Server yet."
 
-grep -q "nomad quota apply quota-qa.hcl" /root/.bash_history || fail-message "You have not created the qa resource quota on the Server yet."
+grep -q "nomad quota apply quota-qa.hcl" /home/nomad/.bash_history || fail-message "You have not created the qa resource quota on the Server yet."
 
-grep -q 'nomad namespace apply -quota default -description "default namespace" default' /root/.bash_history || fail-message "You have not applied the default quota to the default namespace on the Server yet."
+grep -q 'nomad namespace apply -quota default -description "default namespace" default' /home/nomad/.bash_history || fail-message "You have not applied the default quota to the default namespace on the Server yet."
 
-grep -q 'nomad namespace apply -quota dev -description "dev namespace" dev' /root/.bash_history || fail-message "You have not created the dev namespace and applied the dev resource quota to it on the Server yet."
+grep -q 'nomad namespace apply -quota dev -description "dev namespace" dev' /home/nomad/.bash_history || fail-message "You have not created the dev namespace and applied the dev resource quota to it on the Server yet."
 
-grep -q 'nomad namespace apply -quota qa -description "qa namespace" qa' /root/.bash_history || fail-message "You have not created the qa namespace and applied the qa resource quota to it on the Server yet."
+grep -q 'nomad namespace apply -quota qa -description "qa namespace" qa' /home/nomad/.bash_history || fail-message "You have not created the qa namespace and applied the qa resource quota to it on the Server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-governance/namespaces-and-resource-quotas/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/namespaces-and-resource-quotas/setup-nomad-server-1
@@ -1,9 +1,10 @@
 #!/bin/bash -l
 
-mkdir -p /root/nomad/quotas
+mkdir -p /home/nomad/nomad/quotas
+chown -R nomad:nomad /home/nomad/nomad/quotas
 
 # Write Default Resource Quota
-cat <<-EOF > /root/nomad/quotas/quota-default.hcl
+cat <<-EOF > /home/nomad/nomad/quotas/quota-default.hcl
 name = "default"
 description = "default quota"
 
@@ -17,7 +18,7 @@ limit {
 EOF
 
 # Write Dev Resource Quota
-cat <<-EOF > /root/nomad/quotas/quota-dev.hcl
+cat <<-EOF > /home/nomad/nomad/quotas/quota-dev.hcl
 name = "dev"
 description = "dev quota"
 
@@ -31,7 +32,7 @@ limit {
 EOF
 
 # Write QA Resource Quota
-cat <<-EOF > /root/nomad/quotas/quota-qa.hcl
+cat <<-EOF > /home/nomad/nomad/quotas/quota-qa.hcl
 name = "qa"
 description = "qa quota"
 

--- a/instruqt-tracks/nomad-governance/namespaces-and-resource-quotas/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/namespaces-and-resource-quotas/solve-nomad-server-1
@@ -1,11 +1,11 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
 
-# Change to /root/nomad
-cd /root/nomad/quotas
+# Navigate to right directory
+cd /home/nomad/nomad/quotas
 
 # Create Default Resource Quota
 nomad quota apply quota-default.hcl
@@ -15,6 +15,9 @@ nomad quota apply quota-dev.hcl
 
 # Create QA Resource Quota
 nomad quota apply quota-qa.hcl
+
+# Sleep
+sleep 15
 
 # Apply Default Quota to Default Namespace
 nomad namespace apply -quota default -description "default namespace" default

--- a/instruqt-tracks/nomad-governance/nomad-acls/check-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/nomad-acls/check-nomad-client-1
@@ -2,6 +2,6 @@
 
 set -e
 
-grep -q "systemctl restart nomad" /root/.bash_history || fail-message "You have not restarted Client 1 yet."
+grep -q "sudo systemctl restart nomad" /home/nomad/.bash_history || fail-message "You have not restarted Client 1 yet."
 
 exit 0

--- a/instruqt-tracks/nomad-governance/nomad-acls/check-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/nomad-acls/check-nomad-client-2
@@ -2,6 +2,6 @@
 
 set -e
 
-grep -q "systemctl restart nomad" /root/.bash_history || fail-message "You have not restarted Client 2 yet."
+grep -q "sudo systemctl restart nomad" /home/nomad/.bash_history || fail-message "You have not restarted Client 2 yet."
 
 exit 0

--- a/instruqt-tracks/nomad-governance/nomad-acls/check-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/nomad-acls/check-nomad-client-3
@@ -2,6 +2,6 @@
 
 set -e
 
-grep -q "systemctl restart nomad" /root/.bash_history || fail-message "You have not restarted Client 3 yet."
+grep -q "sudo systemctl restart nomad" /home/nomad/.bash_history || fail-message "You have not restarted Client 3 yet."
 
 exit 0

--- a/instruqt-tracks/nomad-governance/nomad-acls/check-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/nomad-acls/check-nomad-server-1
@@ -2,28 +2,28 @@
 
 set -e
 
-grep -q "cd /root/nomad/acls" /root/.bash_history || fail-message "You have not navigated to /root/nomad on the Server yet."
+grep -q "cd /home/nomad/nomad/acls" /home/nomad/.bash_history || fail-message "You have not navigated to the /home/nomad/nomad/acls directory on the Server yet."
 
-grep -q "systemctl restart nomad" /root/.bash_history || fail-message "You have not restarted the Server yet."
+grep -q "sudo systemctl restart nomad" /home/nomad/.bash_history || fail-message "You have not restarted the Server yet."
 
-grep -q "nomad acl bootstrap | tee bootstrap.txt" /root/.bash_history || fail-message "You have not bootstrapped the ACL system on the Server yet."
+grep -q "nomad acl bootstrap | tee bootstrap.txt" /home/nomad/.bash_history || fail-message "You have not bootstrapped the ACL system on the Server yet."
 
-grep -q "export NOMAD_TOKEN=\$(cat bootstrap.txt | grep Secret | cut -d' ' -f7)" /root/.bash_history || fail-message "You have not exported the bootstrap token on the Server yet."
+grep -q "export NOMAD_TOKEN=\$(cat bootstrap.txt | grep Secret | cut -d' ' -f7)" /home/nomad/.bash_history || fail-message "You have not exported the bootstrap token on the Server yet."
 
-grep -q "export NOMAD_TOKEN" /root/.bash_profile || fail-message "You have not added the bootstrap token to your .bash_profile on the Server yet."
+grep -q "export NOMAD_TOKEN" /home/nomad/.bashrc || fail-message "You have not added the bootstrap token to your .bashrc on the Server yet."
 
-grep -q "nomad acl policy apply.*anonymous acl-anonymous.hcl" /root/.bash_history || fail-message "You have not created the anonymous ACL policy on the Server yet."
+grep -q "nomad acl policy apply.*anonymous acl-anonymous.hcl" /home/nomad/.bash_history || fail-message "You have not created the anonymous ACL policy on the Server yet."
 
-grep -q "nomad acl policy apply.*dev acl-dev.hcl" /root/.bash_history || fail-message "You have not created the dev ACL policy on the Server yet."
+grep -q "nomad acl policy apply.*dev acl-dev.hcl" /home/nomad/.bash_history || fail-message "You have not created the dev ACL policy on the Server yet."
 
-grep -q "nomad acl policy apply.*qa acl-qa.hcl" /root/.bash_history || fail-message "You have not created the qa ACL policy on the Server yet."
+grep -q "nomad acl policy apply.*qa acl-qa.hcl" /home/nomad/.bash_history || fail-message "You have not created the qa ACL policy on the Server yet."
 
-grep -q "nomad acl policy apply.*override acl-override.hcl" /root/.bash_history || fail-message "You have not created the override ACL policy on the Server yet."
+grep -q "nomad acl policy apply.*override acl-override.hcl" /home/nomad/.bash_history || fail-message "You have not created the override ACL policy on the Server yet."
 
-grep -q 'nomad acl token create -name="alice" -policy=dev | tee alice-token.txt' /root/.bash_history || fail-message "You have not created Alice's ACL token on the Server yet."
+grep -q 'nomad acl token create -name="alice" -policy=dev | tee alice-token.txt' /home/nomad/.bash_history || fail-message "You have not created Alice's ACL token on the Server yet."
 
-grep -q 'nomad acl token create -name="bob" -policy=qa | tee bob-token.txt' /root/.bash_history || fail-message "You have not created Bob's ACL token on the Server yet."
+grep -q 'nomad acl token create -name="bob" -policy=qa | tee bob-token.txt' /home/nomad/.bash_history || fail-message "You have not created Bob's ACL token on the Server yet."
 
-grep -q 'nomad acl token create -name="charlie" -policy=override | tee charlie-token.txt' /root/.bash_history || fail-message "You have not created Charlie's ACL token on the Server yet."
+grep -q 'nomad acl token create -name="charlie" -policy=override | tee charlie-token.txt' /home/nomad/.bash_history || fail-message "You have not created Charlie's ACL token on the Server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-server-1
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
-rm /root/.bash_history
-touch /root/.bash_history
+#rm /home/nomad/.bash_history
+#touch /home/nomad/.bash_history
 
 # Add ACL stanza to nomad.hcl config
 cat <<-EOF >> /etc/nomad.d/nomad-server1.hcl
@@ -13,7 +13,7 @@ acl {
 EOF
 
 # Add ACL stanza to copy of nomad.hcl config
-cat <<-EOF >> /root/nomad/nomad-server1.hcl
+cat <<-EOF >> /home/nomad/nomad/nomad-server1.hcl
 
 # Enable ACLs
 acl {
@@ -22,7 +22,7 @@ acl {
 EOF
 
 # Add ACL stanza to copy of nomad-client1.hcl config
-cat <<-EOF >> /root/nomad/nomad-client1.hcl
+cat <<-EOF >> /home/nomad/nomad/nomad-client1.hcl
 
 # Enable ACLs
 acl {
@@ -31,7 +31,7 @@ acl {
 EOF
 
 # Add ACL stanza to copy of nomad-client2.hcl config
-cat <<-EOF >> /root/nomad/nomad-client2.hcl
+cat <<-EOF >> /home/nomad/nomad/nomad-client2.hcl
 
 # Enable ACLs
 acl {
@@ -40,7 +40,7 @@ acl {
 EOF
 
 # Add ACL stanza to copy of nomad-client3.hcl config
-cat <<-EOF >> /root/nomad/nomad-client3.hcl
+cat <<-EOF >> /home/nomad/nomad/nomad-client3.hcl
 
 # Enable ACLs
 acl {
@@ -49,10 +49,11 @@ acl {
 EOF
 
 # Make acls directory
-mkdir /root/nomad/acls
+mkdir /home/nomad/nomad/acls
+chown -R nomad:nomad /home/nomad/nomad/acls
 
 # Write Anonymous ACL
-cat <<-EOF > /root/nomad/acls/acl-anonymous.hcl
+cat <<-EOF > /home/nomad/nomad/acls/acl-anonymous.hcl
 namespace "default" {
   capabilities = ["list-jobs"]
 }
@@ -67,7 +68,7 @@ node {
 EOF
 
 # Write Dev ACL
-cat <<-EOF > /root/nomad/acls/acl-dev.hcl
+cat <<-EOF > /home/nomad/nomad/acls/acl-dev.hcl
 namespace "default" {
   capabilities = ["list-jobs"]
 }
@@ -87,7 +88,7 @@ EOF
 
 
 # Write QA ACL
-cat <<-EOF > /root/nomad/acls/acl-qa.hcl
+cat <<-EOF > /home/nomad/nomad/acls/acl-qa.hcl
 namespace "default" {
   capabilities = ["list-jobs"]
 }
@@ -106,7 +107,7 @@ node {
 EOF
 
 # Write override ACL
-cat <<-EOF > /root/nomad/acls/acl-override.hcl
+cat <<-EOF > /home/nomad/nomad/acls/acl-override.hcl
 namespace "default" {
   policy = "write"
   capabilities = ["sentinel-override"]

--- a/instruqt-tracks/nomad-governance/nomad-acls/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/nomad-acls/solve-nomad-server-1
@@ -1,14 +1,14 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
 
-# Change directory
-cd /root/nomad/acls
+# Navigate to right directory
+cd /home/nomad/nomad/acls
 
 # Restart server
-systemctl restart nomad
+sudo systemctl restart nomad
 
 # Sleep
 sleep 30
@@ -18,26 +18,26 @@ nomad acl bootstrap | tee bootstrap.txt
 
 # Export bootstrap token
 export NOMAD_TOKEN=$(cat bootstrap.txt | grep Secret | cut -d' ' -f7)
-echo "export NOMAD_TOKEN=$NOMAD_TOKEN" >> /root/.bash_profile
+echo "export NOMAD_TOKEN=$NOMAD_TOKEN" >> /home/nomad/.bashrc
 
 # Sleep
 sleep 15
 
 # Restart the Nomad clients
 ssh -o StrictHostKeyChecking=no nomad-client-1 << ENDSSH
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
-systemctl restart nomad
+sudo systemctl restart nomad
 ENDSSH
 ssh -o StrictHostKeyChecking=no nomad-client-2 << ENDSSH
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
-systemctl restart nomad
+sudo systemctl restart nomad
 ENDSSH
 ssh -o StrictHostKeyChecking=no nomad-client-3 << ENDSSH
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
-systemctl restart nomad
+sudo systemctl restart nomad
 ENDSSH
 
 # Add the ACL Policies

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-1/check-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-1/check-nomad-server-1
@@ -2,16 +2,18 @@
 
 set -e
 
-grep -q "cd /root/nomad/jobs" /root/.bash_history || fail-message "You have not navigated to the /root/nomad/jobs directory on the Server yet."
+grep -q "cd /home/nomad/nomad/jobs" /home/nomad/.bash_history || fail-message "You have not navigated to the /home/nomad/nomad/jobs directory on the Server yet."
 
-grep -q "nomad job run sleep.nomad" /root/.bash_history || fail-message "You have not tried to run the sleep.nomad job on the Server yet."
+grep -q "nomad job run sleep.nomad" /home/nomad/.bash_history || fail-message "You have not tried to run the sleep.nomad job on the Server yet."
 
-grep -q "nomad job run catalogue.nomad" /root/.bash_history || fail-message "You have not tried to run the catalogue.nomad job on the Server yet."
+# grep -q "nomad job stop sleep" /home/nomad/.bash_history || fail-message "You have not stopped the sleep job on the Server yet."
 
-grep -q "nomad job run -policy-override catalogue.nomad" /root/.bash_history || fail-message "You have not tried to run the catalogue.nomad job with the -policy-override argument on the Server yet."
+grep -q "nomad job run catalogue.nomad" /home/nomad/.bash_history || fail-message "You have not tried to run the catalogue.nomad job on the Server yet."
+
+grep -q "nomad job run -policy-override catalogue.nomad" /home/nomad/.bash_history || fail-message "You have not tried to run the catalogue.nomad job with the -policy-override argument on the Server yet."
 
 # Set the bootstrap ACL token
-export NOMAD_TOKEN=$(cat /root/nomad/acls/bootstrap.txt | grep Secret | cut -d' ' -f7)
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/bootstrap.txt | grep Secret | cut -d' ' -f7)
 
 # Check that catalogue job is running
 catalogue_status=$(nomad job status catalogue | grep running | wc -l)
@@ -19,29 +21,29 @@ if [ $catalogue_status -lt 1 ]; then
   fail-message "The catalogue job is not running"
 fi
 
-grep -q "export NOMAD_TOKEN=\$(cat /root/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)" /root/.bash_history || fail-message "You have not set NOMAD_TOKEN to Alice's ACL token on the Server yet."
+grep -q "export NOMAD_TOKEN=\$(cat /home/nomad/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)" /home/nomad/.bash_history || fail-message "You have not set NOMAD_TOKEN to Alice's ACL token on the Server yet."
 
-grep -q "nomad job run webserver-test.nomad" /root/.bash_history || fail-message "You have not tried to run the webserver-test.nomad job as Alice on the Server yet."
+grep -q "nomad job run webserver-test.nomad" /home/nomad/.bash_history || fail-message "You have not tried to run the webserver-test.nomad job as Alice on the Server yet."
 
-grep -q "export NOMAD_TOKEN=\$(cat /root/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)" /root/.bash_history || fail-message "You have not set NOMAD_TOKEN to Bob's ACL token on the Server yet."
+grep -q "export NOMAD_TOKEN=\$(cat /home/nomad/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)" /home/nomad/.bash_history || fail-message "You have not set NOMAD_TOKEN to Bob's ACL token on the Server yet."
 
-grep -q "nomad job run -policy-override webserver-test.nomad" /root/.bash_history || fail-message "You have not run the webserver-test.nomad job with the -policy-override argument on the Server yet."
+grep -q "nomad job run -policy-override webserver-test.nomad" /home/nomad/.bash_history || fail-message "You have not run the webserver-test.nomad job with the -policy-override argument on the Server yet."
 
-grep -q 'sed -i "s/httpd/nginx/g" webserver-test.nomad' /root/.bash_history || fail-message "You have not replaced httpd with nginx in webserver-test.nomad on the Server yet."
+grep -q 'sed -i "s/httpd/nginx/g" webserver-test.nomad' /home/nomad/.bash_history || fail-message "You have not replaced httpd with nginx in webserver-test.nomad on the Server yet."
 
-grep -q 'sed -i "s/nginx/nginx:1.15.6/g" webserver-test.nomad' /root/.bash_history || fail-message "You have not added the 1.15.6 tag for nginx in webserver-test.nomad on the Server yet."
+grep -q 'sed -i "s/nginx/nginx:1.15.6/g" webserver-test.nomad' /home/nomad/.bash_history || fail-message "You have not added the 1.15.6 tag for nginx in webserver-test.nomad on the Server yet."
 
-grep -q 'sed -i "s/nginx:1.15.6/httpd:2.4/g" webserver-test.nomad' /root/.bash_history || fail-message "You have not added reverted to httpd in webserver-test.nomad on the Server yet."
+grep -q 'sed -i "s/nginx:1.15.6/httpd:2.4/g" webserver-test.nomad' /home/nomad/.bash_history || fail-message "You have not added reverted to httpd in webserver-test.nomad on the Server yet."
 
-grep -q "export NOMAD_TOKEN=\$(cat /root/nomad/acls/charlie-token.txt | grep Secret | cut -d' ' -f7)" /root/.bash_history || fail-message "You have not set NOMAD_TOKEN to Charlie's ACL token on the Server yet."
+grep -q "export NOMAD_TOKEN=\$(cat /home/nomad/nomad/acls/charlie-token.txt | grep Secret | cut -d' ' -f7)" /home/nomad/.bash_history || fail-message "You have not set NOMAD_TOKEN to Charlie's ACL token on the Server yet."
 
-override_attempts=$(grep "nomad job run -policy-override webserver-test.nomad" /root/.bash_history | wc -l)
+override_attempts=$(grep "nomad job run -policy-override webserver-test.nomad" /home/nomad/.bash_history | wc -l)
 if [ $override_attempts -lt 2 ]; then
   fail-message "Did you forget to have Charlie override the Sentinel violation for the webserver-test.nomad job?"
 fi
 
 # Set Charlie's ACL token
-export NOMAD_TOKEN=$(cat /root/nomad/acls/charlie-token.txt | grep Secret | cut -d' ' -f7)
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/charlie-token.txt | grep Secret | cut -d' ' -f7)
 
 # Check status of the webserver-test job
 webserver_test_status=$(nomad job status -namespace qa webserver-test | grep running | wc -l)

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-1/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-1/setup-nomad-server-1
@@ -1,10 +1,11 @@
 #!/bin/bash -l
 
 # Make jobs directory
-mkdir /root/nomad/jobs
+mkdir /home/nomad/nomad/jobs
+chown -R nomad:nomad /home/nomad/nomad/jobs
 
 # Write the sleep job
-cat <<-EOF > /root/nomad/jobs/sleep.nomad
+cat <<-EOF > /home/nomad/nomad/jobs/sleep.nomad
 job "sleep" {
   datacenters = ["dc1"]
   type        = "service"
@@ -23,7 +24,7 @@ job "sleep" {
 EOF
 
 # Write the catalogue job
-cat <<-EOF > /root/nomad/jobs/catalogue.nomad
+cat <<-EOF > /home/nomad/nomad/jobs/catalogue.nomad
 job "catalogue" {
   datacenters = ["dc1"]
   type        = "service"
@@ -129,7 +130,7 @@ job "catalogue" {
 EOF
 
 # Write the webserver-test job
-cat <<-EOF > /root/nomad/jobs/webserver-test.nomad
+cat <<-EOF > /home/nomad/nomad/jobs/webserver-test.nomad
 job "webserver-test" {
   datacenters = ["dc1"]
   type        = "service"
@@ -175,8 +176,8 @@ job "webserver-test" {
       }
 
       resources {
-        cpu = 500 # 500 Mhz
-        memory = 512 # 512MB
+        cpu = 250 # Mhz
+        memory = 512 # MB
         network {
           mbits = 10
           port "http" {}
@@ -188,7 +189,7 @@ job "webserver-test" {
 EOF
 
 # Write the website-dev job
-cat <<-EOF > /root/nomad/jobs/website-dev.nomad
+cat <<-EOF > /home/nomad/nomad/jobs/website-dev.nomad
 job "website" {
   datacenters = ["dc1"]
   type        = "service"
@@ -233,7 +234,7 @@ job "website" {
       }
 
       resources {
-        cpu = 500 # Mhz
+        cpu = 250 # Mhz
         memory = 512 # MB
         network {
           mbits = 10
@@ -271,7 +272,7 @@ job "website" {
       }
 
       resources {
-        cpu = 500 # Mhz
+        cpu = 250 # Mhz
         memory = 512 # MB
         network {
           mbits = 10
@@ -285,7 +286,7 @@ job "website" {
 EOF
 
 # Write the website-qa job
-cat <<-EOF > /root/nomad/jobs/website-qa.nomad
+cat <<-EOF > /home/nomad/nomad/jobs/website-qa.nomad
 job "website" {
   datacenters = ["dc1"]
   type        = "service"
@@ -330,7 +331,7 @@ job "website" {
       }
 
       resources {
-        cpu = 500 # Mhz
+        cpu = 250 # Mhz
         memory = 1024 # MB
         network {
           mbits = 10
@@ -368,7 +369,7 @@ job "website" {
       }
 
       resources {
-        cpu = 500 # Mhz
+        cpu = 250 # Mhz
         memory = 1024 # MB
         network {
           mbits = 10

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-1/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-1/solve-nomad-server-1
@@ -1,20 +1,23 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
 
-# Change directory
-cd /root/nomad/jobs
+# Navigate to right directory
+cd /home/nomad/nomad/jobs
 
 # Export bootstrap token
-export NOMAD_TOKEN=$(cat /root/nomad/acls/bootstrap.txt | grep Secret | cut -d' ' -f7)
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/bootstrap.txt | grep Secret | cut -d' ' -f7)
 
 # Run the sleep.nomad job
 nomad job run sleep.nomad
 
 # Sleep
-sleep 10
+sleep 15
+
+# Stop the sleep job
+# nomad job stop sleep
 
 # Run the catalogue.nomad job
 nomad job run catalogue.nomad
@@ -26,7 +29,7 @@ sleep 10
 nomad job run -policy-override catalogue.nomad
 
 # Export Alice's token
-export NOMAD_TOKEN=$(cat /root/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)
 
 # Run the webserver-test.nomad job as Alice
 nomad job run webserver-test.nomad
@@ -35,7 +38,7 @@ nomad job run webserver-test.nomad
 sleep 10
 
 # Export Bob's token
-export NOMAD_TOKEN=$(cat /root/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)
 
 # Have Bob try to override the Sentinel policies
 nomad job run -policy-override webserver-test.nomad
@@ -59,7 +62,7 @@ sleep 30
 sed -i "s/nginx:1.15.6/httpd:2.4/g" webserver-test.nomad
 
 # Export Charlie's token
-export NOMAD_TOKEN=$(cat /root/nomad/acls/charlie-token.txt | grep Secret | cut -d' ' -f7)
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/charlie-token.txt | grep Secret | cut -d' ' -f7)
 
 # Run webserver-test.nomad with override
 nomad job run -policy-override webserver-test.nomad

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-2/check-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-2/check-nomad-server-1
@@ -2,28 +2,31 @@
 
 set -e
 
-grep -q "cd /root/nomad/jobs" /root/.bash_history || fail-message "You have not navigated to the /root/nomad/jobs directory on the Server yet."
+grep -q "cd /home/nomad/nomad/jobs" /home/nomad/.bash_history || fail-message "You have not navigated to the /home/nomad/nomad/jobs directory on the Server yet."
 
-grep -q "export NOMAD_TOKEN=\$(cat /root/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)" /root/.bash_history || fail-message "You have not exported Alice's ACL token on the Server yet."
+grep -q "export NOMAD_TOKEN=\$(cat /home/nomad/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)" /home/nomad/.bash_history || fail-message "You have not exported Alice's ACL token on the Server yet."
 
-grep -q "nomad quota status dev" /root/.bash_history || fail-message "You have not checked the status of the dev resoure quota on the Server yet."
+grep -q "nomad quota status dev" /home/nomad/.bash_history || fail-message "You have not checked the status of the dev resoure quota on the Server yet."
 
-grep -q "nomad job run website-dev.nomad" /root/.bash_history || fail-message "You have not run the website-dev.nomad job on the Server yet."
+grep -q "nomad job run website-dev.nomad" /home/nomad/.bash_history || fail-message "You have not run the website-dev.nomad job on the Server yet."
 
-grep -q "nomad job status -namespace=dev website" /root/.bash_history || fail-message "You have not checked the status of the website job in the dev namespace on the Server yet."
+grep -q "nomad job status -namespace=dev website" /home/nomad/.bash_history || fail-message "You have not checked the status of the website job in the dev namespace on the Server yet."
 
-dev_quota_checks=$(grep "nomad quota status dev" /root/.bash_history | wc -l)
+dev_quota_checks=$(grep "nomad quota status dev" /home/nomad/.bash_history | wc -l)
 if [ $dev_quota_checks -lt 2 ]; then
   fail-message "You have not checked the status of the dev resource quota a second time after running the website job in the dev namespace."
 fi
 
-grep -q "export NOMAD_TOKEN=\$(cat /root/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)" /root/.bash_history || fail-message "You have not exported Bob's ACL token on the Server yet."
+grep -q "export NOMAD_TOKEN=\$(cat /home/nomad/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)" /home/nomad/.bash_history || fail-message "You have not exported Bob's ACL token on the Server yet."
 
-grep -q "nomad quota status qa" /root/.bash_history || fail-message "You have not checked the status of the qa resource quota on the Server yet."
+grep -q "nomad quota status qa" /home/nomad/.bash_history || fail-message "You have not checked the status of the qa resource quota on the Server yet."
 
-grep -q "nomad job run website-qa.nomad" /root/.bash_history || fail-message "You have not run the website-qa.nomad job on the Server yet."
+grep -q "nomad job run website-qa.nomad" /home/nomad/.bash_history || fail-message "You have not run the website-qa.nomad job on the Server yet."
 
-grep -q "nomad job stop -namespace=qa webserver-test" /root/.bash_history || fail-message "You have not stopped the webserver-test job on the Server yet."
+grep -q "nomad job stop -namespace=qa webserver-test" /home/nomad/.bash_history || fail-message "You have not stopped the webserver-test job on the Server yet."
+
+# Set the bootstrap ACL token
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/bootstrap.txt | grep Secret | cut -d' ' -f7)
 
 # Verify that all allocations for website in qa are healthy
 qa_website_healthy=$(nomad job status -namespace=qa website | grep Deployed -A3 | grep "2        2       2" | wc -l)

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-2/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-2/setup-nomad-server-1
@@ -1,6 +1,3 @@
 #!/bin/bash -l
 
-rm /root/.bash_history
-touch /root/.bash_history
-
 exit 0

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-2/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-2/solve-nomad-server-1
@@ -1,14 +1,14 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
 
-# Change directory
-cd /root/nomad/jobs
+# Navigate to right directory
+cd /home/nomad/nomad/jobs
 
 # Export Alice's ACL token
-export NOMAD_TOKEN=$(cat /root/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)
 
 # Check the dev resource quota
 nomad quota status dev
@@ -26,7 +26,7 @@ nomad job status -namespace=dev website
 nomad quota status dev
 
 # Export Bob's ACL token
-export NOMAD_TOKEN=$(cat /root/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)
 
 # Check the qa resource quota
 nomad quota status qa

--- a/instruqt-tracks/nomad-governance/sentinel-policies/check-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/sentinel-policies/check-nomad-server-1
@@ -2,12 +2,12 @@
 
 set -e
 
-grep -q "cd /root/nomad/sentinel" /root/.bash_history || fail-message "You have not navigated to the /root/nomad/sentinel directory on the Server yet."
+grep -q "cd /home/nomad/nomad/sentinel" /home/nomad/.bash_history || fail-message "You have not navigated to the /home/nomad/nomad/sentinel directory on the Server yet."
 
-grep -q "nomad sentinel apply .* -level hard-mandatory allow-docker-and-java-drivers allow-docker-and-java-drivers.sentinel" /root/.bash_history || fail-message "You have not created the allow-docker-and-java-drivers Sentinel policy on the Server yet."
+grep -q "nomad sentinel apply .* -level hard-mandatory allow-docker-and-java-drivers allow-docker-and-java-drivers.sentinel" /home/nomad/.bash_history || fail-message "You have not created the allow-docker-and-java-drivers Sentinel policy on the Server yet."
 
-grep -q "nomad sentinel apply .* -level soft-mandatory restrict-docker-images restrict-docker-images.sentinel" /root/.bash_history || fail-message "You have not created the restrict-docker-images Sentinel policy on the Server yet."
+grep -q "nomad sentinel apply .* -level soft-mandatory restrict-docker-images restrict-docker-images.sentinel" /home/nomad/.bash_history || fail-message "You have not created the restrict-docker-images Sentinel policy on the Server yet."
 
-grep -q "nomad sentinel apply .* -level soft-mandatory prevent-docker-host-network prevent-docker-host-network.sentinel" /root/.bash_history || fail-message "You have not created the prevent-docker-host-network Sentinel policy on the Server yet."
+grep -q "nomad sentinel apply .* -level soft-mandatory prevent-docker-host-network prevent-docker-host-network.sentinel" /home/nomad/.bash_history || fail-message "You have not created the prevent-docker-host-network Sentinel policy on the Server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-governance/sentinel-policies/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/sentinel-policies/setup-nomad-server-1
@@ -1,10 +1,11 @@
 #!/bin/bash -l
 
 # Make sentinel directory
-mkdir /root/nomad/sentinel
+mkdir /home/nomad/nomad/sentinel
+chown -R nomad:nomad /home/nomad/nomad/sentinel
 
 # Write allow-docker-and-java-drivers.sentinel
-cat <<-EOF > /root/nomad/sentinel/allow-docker-and-java-drivers.sentinel
+cat <<-EOF > /home/nomad/nomad/sentinel/allow-docker-and-java-drivers.sentinel
 # Only allow Docker and Java drivers
 
 # Allow Docker rule
@@ -23,7 +24,7 @@ main = rule {
 EOF
 
 # Write restrict-docker-images.sentinel
-cat <<-EOF > /root/nomad/sentinel/restrict-docker-images.sentinel
+cat <<-EOF > /home/nomad/nomad/sentinel/restrict-docker-images.sentinel
 # Allowed Docker images
 allowed_images = [
   "nginx",
@@ -50,7 +51,7 @@ main = rule {
 EOF
 
 # Write prevent-docker-host-network.sentinel
-cat <<-EOF > /root/nomad/sentinel/prevent-docker-host-network.sentinel
+cat <<-EOF > /home/nomad/nomad/sentinel/prevent-docker-host-network.sentinel
 # Prevent Docker containers from running with host network mode
 prevent_host_network = rule {
   all job.task_groups as tg {

--- a/instruqt-tracks/nomad-governance/sentinel-policies/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/sentinel-policies/solve-nomad-server-1
@@ -1,11 +1,14 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
 
-# Change to /root/nomad/sentinel
-cd /root/nomad/sentinel
+# Navigate to right directory
+cd /home/nomad/nomad/sentinel
+
+# Export bootstrap token
+export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/bootstrap.txt | grep Secret | cut -d' ' -f7)
 
 # Create allow-docker-and-java-drivers.sentinel
 nomad sentinel apply -description "Only allow the Docker and Java drivers" -level hard-mandatory allow-docker-and-java-drivers allow-docker-and-java-drivers.sentinel

--- a/instruqt-tracks/nomad-governance/track.yml
+++ b/instruqt-tracks/nomad-governance/track.yml
@@ -21,7 +21,7 @@ tags:
 owner: hashicorp
 developers:
 - roger@hashicorp.com
-private: true
+private: false
 published: true
 challenges:
 - slug: verify-nomad-cluster-health
@@ -34,6 +34,8 @@ challenges:
     In this challenge, you will verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
     The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients. Each of these has 3.75GB of memory and 1 virtual CPU with 2,300MHz of CPU capacity. This means that the total capacity of the 3 Nomad clients is 11.25GB of memory and 6,900MHz of CPU capacity.
+
+    The cluster is using Nomad 0.11.1 and Consul 1.7.2.
 
     First, verify that all 4 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
     ```
@@ -53,8 +55,6 @@ challenges:
     ```
     You should see 3 Nomad clients.
 
-    Please also run the last command on the "Client 1", "Client 2", and "Client 3" tabs. In each case, you should see the same 3 Nomad clients.
-
     In the next challenge, you will configure Nomad Enterprise namespaces and resource quotas.
   notes:
   - type: text
@@ -68,7 +68,7 @@ challenges:
   - title: Config Files
     type: code
     hostname: nomad-server-1
-    path: /root/nomad/
+    path: /home/nomad/nomad/
   - title: Server
     type: terminal
     hostname: nomad-server-1
@@ -98,9 +98,9 @@ challenges:
 
     Start by inspecting the "quota-default.hcl", "quota-dev.hcl", and "quota-qa.hcl" resource quota specifications in the quotas directory on the "Config Files" tab. These are written in the HashiCorp Configuration Language (HCL). The first sets global limits of 2,300 MHz of CPU capacity and 3,100 MB of memory while the others set global limits of 2,300 MHz of CPU capacity and 4,100 MB of memory.
 
-    The resource quota specification files are all in the /root/nomad/quotas directory, so please navigate to it with this command:
+    The resource quota specification files are all in the /home/nomad/nomad/quotas directory, so please navigate to it with this command:
     ```
-    cd /root/nomad/quotas
+    cd /home/nomad/nomad/quotas
     ```
 
     Next, create the "default" resource quota by running this command on the "Server" tab:
@@ -176,7 +176,7 @@ challenges:
   - title: Config Files
     type: code
     hostname: nomad-server-1
-    path: /root/nomad/
+    path: /home/nomad/nomad/
   - title: Server
     type: terminal
     hostname: nomad-server-1
@@ -207,14 +207,14 @@ challenges:
 
     This stanza is needed on Nomad servers and clients when enabling the Nomad ACL system. You are looking at copies of the actual files that have been placed in the /etc/nomad.d directory on the server and all 3 clients.
 
-    Navigate to the /root/nomad/acls directory on the "Server" tab with this command:
+    Navigate to the /home/nomad/nomad/acls directory on the "Server" tab with this command:
     ```
-    cd /root/nomad/acls
+    cd /home/nomad/nomad/acls
     ```
 
     Restart the Nomad server on the "Server" tab with this command:
     ```
-    systemctl restart nomad
+    sudo systemctl restart nomad
     ```
 
     After waiting about 15 seconds, bootstrap the Nomad ACLs system by running this command on the "Server" tab:
@@ -238,7 +238,7 @@ challenges:
     Export the bootstrap token with these commands on the "Server" tab:
     ```
     export NOMAD_TOKEN=$(cat bootstrap.txt | grep Secret | cut -d' ' -f7)
-    echo "export NOMAD_TOKEN=$NOMAD_TOKEN" >> /root/.bash_profile
+    echo "export NOMAD_TOKEN=$NOMAD_TOKEN" >> /home/nomad/.bashrc
     ```
     The second command ensures that the bootstrap token will be exported in later challenges.
 
@@ -246,7 +246,7 @@ challenges:
 
     Next, you should restart all 3 of the Nomad clients on the "Client 1", "Client 2", and "Client 3" tabs:
     ```
-    systemctl restart nomad
+    sudo systemctl restart nomad
     ```
 
     ## Create ACL Policies and Tokens
@@ -367,7 +367,7 @@ challenges:
   - title: Config Files
     type: code
     hostname: nomad-server-1
-    path: /root/nomad/
+    path: /home/nomad/nomad/
   - title: Server
     type: terminal
     hostname: nomad-server-1
@@ -405,9 +405,9 @@ challenges:
 
     You will create the first of these Sentinel policies with the "hard-mandatory" enforcement level and the others with the "soft-mandatory" enforcement level. This means that absolutely no Nomad task drivers except for the Docker and Java drivers will be allowed but that Nomad administrators will be able to override failures of the other two Sentinel policies.
 
-    Navigate to the /root/nomad/sentinel directory on the "Server" tab with this command:
+    Navigate to the /home/nomad/nomad/sentinel directory on the "Server" tab with this command:
     ```
-    cd /root/nomad/sentinel
+    cd /home/nomad/nomad/sentinel
     ```
 
     Add the "allow-docker-and-java-drivers" Sentinel policy on the "Server" tab with this command:
@@ -448,7 +448,7 @@ challenges:
   - title: Config Files
     type: code
     hostname: nomad-server-1
-    path: /root/nomad/
+    path: /home/nomad/nomad/
   - title: Server
     type: terminal
     hostname: nomad-server-1
@@ -467,15 +467,15 @@ challenges:
   assignment: |-
     In this challenge, you will run Nomad jobs and learn how Nomad ACL and Sentinel policies restrict them.
 
-    Navigate to the /root/nomad/jobs directory by running this command on the "Server" tab:
+    Navigate to the /home/nomad/nomad/jobs directory by running this command on the "Server" tab:
     ```
-    cd /root/nomad/jobs
+    cd /home/nomad/nomad/jobs
     ```
 
     ## Run the sleep.nomad Job
     Start by inspecting the "sleep.nomad" job in the jobs directory on the "Config Files" tab. This job uses Nomad's [exec](https://nomadproject.io/docs/drivers/exec) driver to run the Linux `sleep` command.
 
-    If you run `echo $NOMAD_TOKEN`, you should see the bootstrap token that you added to /root/.bash_profile earlier. This means that any jobs you run while it is set will be run with the bootstrap token.
+    If you run `echo $NOMAD_TOKEN`, you should see the bootstrap token that you added to /home/nomad/.bash_profile earlier. This means that any jobs you run while it is set will be run with the bootstrap token.
 
     Try running the sleep.nomad job (with the bootstrap token) with this command on the "Server" tab:
     ```
@@ -506,15 +506,21 @@ challenges:
 
     You might wonder why there is not an error about the Docker images not being allowed. This is because Nomad happened to have evaluated the "prevent-docker-host-network" policy before the "restrict-docker-images" policy and stops evaluating Sentinel policies as soon as one of them fails.
 
-    If you edit the "catalogue.nomad" job to change the value of `network_mode` from `host` to `bridge` and re-run the job, you will see an error message complaining about the "restrict-docker-images" policy being violated. You could make that change with the Instruqt text editor on the "Config Files" tab or run these commands:
+    If you edit the "catalogue.nomad" job to change the value of `network_mode` from `host` to `bridge` and re-run the job, you will see an error message complaining about the "restrict-docker-images" policy being violated. You could make that change with the Instruqt text editor on the "Config Files" tab or run this commands:
     ```
-    sed -i 's/"host"/"bridge"/g' /root/nomad/jobs/catalogue.nomad
+    sed -i 's/"host"/"bridge"/g' /home/nomad/nomad/jobs/catalogue.nomad
+    ```
+    and then run the job:
+    ```
     nomad job run catalogue.nomad
     ```
 
     Since the bootstrap ACL token can override soft-mandatory violations, let's try running the "catalogue.nomad" job again with the `-policy-override` argument after changing the job specification to set `network_mode` back to `host`:
     ```
-    sed -i 's/"bridge"/"host"/g' /root/nomad/jobs/catalogue.nomad
+    sed -i 's/"bridge"/"host"/g' /home/nomad/nomad/jobs/catalogue.nomad
+    ```
+    Then run the job:
+    ```
     nomad job run -policy-override catalogue.nomad
     ```
     This returns yellow messages complaining about both violated Sentinel policies, but allows the job to be deployed.
@@ -528,7 +534,7 @@ challenges:
 
     Set Alice's ACL token with this command on the "Server" tab:
     ```
-    export NOMAD_TOKEN=$(cat /root/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)
+    export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)
     ```
 
     Now, run the "webserver-test.nomad" job as Alice with this command:
@@ -541,9 +547,13 @@ challenges:
 
     Recall that Bob's ACL token was assigned the "qa" ACL policy. So, let's try setting his ACL token and running the job again. Do that with these commands:
     ```
-    export NOMAD_TOKEN=$(cat /root/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)
+    export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)
+    ```
+    and
+    ```
     nomad job run webserver-test.nomad
     ```
+
     This time, you should see a red message complaining about the "restrict-docker-images" Sentinel policy being violated. Since we did not see a 403 error, this means that Bob would be allowed to run the job if it did not violate any Sentinel policies.
 
     Bob might be tempted to run the job with the `-policy-override` argument. Go ahead and have Bob try this by running this command:
@@ -589,7 +599,7 @@ challenges:
 
     Then set the `NOMAD_TOKEN` environment variable to Charlie's token:
     ```
-    export NOMAD_TOKEN=$(cat /root/nomad/acls/charlie-token.txt | grep Secret | cut -d' ' -f7)
+    export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/charlie-token.txt | grep Secret | cut -d' ' -f7)
     ```
 
     Finally, have Charlie run the webserver-test job with the `-policy-override` argument:
@@ -597,6 +607,8 @@ challenges:
     nomad job run -policy-override webserver-test.nomad
     ```
     This should give a yellow warning about the violation of the "restrict-docker-images" Sentinel policy but successfully redeploy the job, switching the web server from nginx to httpd.
+
+    Wait until both of the new allocations of the webserver-test job are running before clicking the "Check" button.
 
     In this challenge, you saw how Nomad ACL and Sentinel policies restricted which jobs could be run and who could run them.
 
@@ -613,7 +625,7 @@ challenges:
   - title: Config Files
     type: code
     hostname: nomad-server-1
-    path: /root/nomad/
+    path: /home/nomad/nomad/
   - title: Server
     type: terminal
     hostname: nomad-server-1
@@ -632,14 +644,14 @@ challenges:
   assignment: |-
     In this challenge, you will run some more Nomad jobs and learn how Resource Quotas can prevent some of them from running all of their desired allocations.
 
-    Navigate to the /root/nomad/jobs directory by running this command on the "Server" tab:
+    Navigate to the /home/nomad/nomad/jobs directory by running this command on the "Server" tab:
     ```
-    cd /root/nomad/jobs
+    cd /home/nomad/nomad/jobs
     ```
 
     Next, export Alice's Nomad ACL token with this command:
     ```
-    export NOMAD_TOKEN=$(cat /root/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)
+    export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/alice-token.txt | grep Secret | cut -d' ' -f7)
     ```
 
     Have Alice inspect the current usage of the "dev" resource quota with this command:
@@ -653,13 +665,13 @@ challenges:
     Limits      = 1
     Quota Limits
     Region  CPU Usage  Memory Usage  Network Usage
-    global  0 / 4600   0 / 4100      - / inf
+    global  0 / 2300   0 / 4100      - / inf
     `<br>
     which indicates that none of the "dev" resource quota is being used. ("inf" under "Network Usage" stands for infinity and means that there is no limit on network usage in the "dev" resource quota.)
 
-    Inspect the "website-dev.nomad" job specification file in the jobs directory on the "Config Files" tab and note that it wants to run a job called "website" in the "dev" namespace. The job consists of "nginx" and "mongodb" task groups that each have one task that would consume 500MHz of CPU and 512MB of memory.
+    Inspect the "website-dev.nomad" job specification file in the jobs directory on the "Config Files" tab and note that it wants to run a job called "website" in the "dev" namespace. The job consists of "nginx" and "mongodb" task groups that each have one task that would consume 250MHz of CPU and 512MB of memory.
 
-    However, the count for each task group is 2, so the job would consume a total of 2,000MHz of CPU and 2,048MB of RAM if Nomad is able to schedule all four tasks. Since there are currently no jobs running in the "dev" namespace and these amounts are lower than the limits of the "dev" resource quota, Nomad should be able to run the entire job.
+    However, the count for each task group is 2, so the job would consume a total of 1,000MHz of CPU and 2,048MB of RAM if Nomad is able to schedule all four tasks. Since there are currently no jobs running in the "dev" namespace and these amounts are lower than the limits of the "dev" resource quota, Nomad should be able to run the entire job.
 
     See if that is true by running the job as Alice with this command:
     ```
@@ -672,7 +684,7 @@ challenges:
     ```
     Note that you need to specify the namespace since job names are not unique across multiple namespaces.
 
-    You should see 4 allocations running at the bottom. You can also check the status of the "website" job in the "dev" namespace in the Nomad UI after providing a suitable ACL token after selecting the "ACL Tokens" menu; we recommend using Charlie's token from the charlie-token.txt file in the /root/nomad/acls directory.
+    You should see 4 allocations running at the bottom. You can also check the status of the "website" job in the "dev" namespace in the Nomad UI after providing a suitable ACL token after selecting the "ACL Tokens" menu; we recommend using Charlie's token from the charlie-token.txt file in the /home/nomad/nomad/acls directory.
 
     You'll then need to select the "Jobs" menu and click the Instruqt refresh icon to make the Nomad UI show the namespace selector which will let you select the "dev" namespace. If you click on the "website" job in the "dev" namespace, you will see 4 Desired, Placed, and Healthy allocations.
 
@@ -683,7 +695,7 @@ challenges:
     Limits      = 1
     Quota Limits
     Region  CPU Usage    Memory Usage  Network Usage
-    global  2000 / 4600  2048 / 4100   40 / inf
+    global  1000 / 2300  2048 / 4100   40 / inf
     `<br>
     which exactly matches what we had expected.
 
@@ -691,7 +703,7 @@ challenges:
 
     Export Bob's Nomad ACL token with this command:
     ```
-    export NOMAD_TOKEN=$(cat /root/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)
+    export NOMAD_TOKEN=$(cat /home/nomad/nomad/acls/bob-token.txt | grep Secret | cut -d' ' -f7)
     ```
 
     Then, have Bob check the current usage in the "qa" namespace with this command:
@@ -705,10 +717,10 @@ challenges:
     Limits      = 1
     Quota Limits
     Region  CPU Usage    Memory Usage  Network Usage
-    global  1000 / 4600  1024 / 4100   20 / inf
+    global  500 / 2300  1024 / 4100   20 / inf
     `<br>
 
-    Since 1,024MB of memory is already being used and the "qa" resource quota limits the "qa" namespace to a total of 4,100MB and the "website-qa.nomad" needs 4,096MB, Nomad clearly cannot schedul all 4 allocations of the job.
+    Since 1,024MB of memory is already being used and the "qa" resource quota limits the "qa" namespace to a total of 4,100MB and the "website-qa.nomad" needs 4,096MB, Nomad clearly cannot schedule all 4 allocations of the job. (There is enough CPU capacity.)
 
     Even so, have Bob try to run it with this command:
     ```
@@ -724,12 +736,14 @@ challenges:
         Allocation "5f7186bd" created: node "a9e882e3", group "mongodb"
         Evaluation status changed: "pending" -> "complete"
     ==> Evaluation "17faede9" finished with status "complete" but failed to place all allocations:
-        Task Group "mongodb" (failed to place 1 allocation):
+        Task Group "mongodb" (failed to place 2 allocations):
+          * Resources exhausted on 1 nodes
+          * Dimension "memory" exhausted on 1 nodes
           * Quota limit hit "memory exhausted (5120 needed > 4100 limit)"
         Evaluation "f94e7499" waiting for additional capacity to place remainder
     ```
 
-    Note that the Nomad failed to place 1 allocation because the running job and the four allocations of the new job would need a total of 5,120MB which is greater than the 4,096MB limit of the "qa" resource quota.
+    Note that the Nomad failed to place 2 allocations because the running job and the four allocations of the new job would need a total of 5,120MB which is greater than the 4,096MB limit of the "qa" resource quota. (Sometimes, the message might say Nomad failed to place 1 allocation; and if you inspect the job in the Nomad UI, you might actually see 3 allocations running.)
 
     You can also select the "qa" namespace in the Nomad UI, select the "website" in it, and confirm that only 3 of the 4 allocations of the "website" job are running while 1 of them is queued. The fact that the allocation is currently queued rather than failed is important; this means that it could still be deployed if extra memory became available within the "qa" namespace or if the memory limit of the "qa" resource quota were increased.
 
@@ -758,7 +772,7 @@ challenges:
   - title: Config Files
     type: code
     hostname: nomad-server-1
-    path: /root/nomad/
+    path: /home/nomad/nomad/
   - title: Server
     type: terminal
     hostname: nomad-server-1
@@ -768,4 +782,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "6090509817335165843"
+checksum: "17895184411988258584"

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-1
@@ -2,6 +2,4 @@
 
 set -e
 
-grep -q "nomad node status" /root/.bash_history || fail-message "You have not run 'nomad node status' on Client 1 yet."
-
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-2
@@ -2,6 +2,4 @@
 
 set -e
 
-grep -q "nomad node status" /root/.bash_history || fail-message "You have not run 'nomad node status' on Client 2 yet."
-
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-client-3
@@ -2,6 +2,4 @@
 
 set -e
 
-grep -q "nomad node status" /root/.bash_history || fail-message "You have not run 'nomad node status' on Client 3 yet."
-
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/check-nomad-server-1
@@ -2,11 +2,11 @@
 
 set -e
 
-grep -q "consul members" /root/.bash_history || fail-message "You have not run 'consul members' on the Server yet."
+grep -q "consul members" /home/nomad/.bash_history || fail-message "You have not run 'consul members' on the Server yet."
 
-grep -q "nomad server members" /root/.bash_history || fail-message "You have not run 'nomad server members' on the Server yet."
+grep -q "nomad server members" /home/nomad/.bash_history || fail-message "You have not run 'nomad server members' on the Server yet."
 
-grep -q "nomad node status" /root/.bash_history || fail-message "You have not run 'nomad node status' on the Server yet."
+grep -q "nomad node status" /home/nomad/.bash_history || fail-message "You have not run 'nomad node status' on the Server yet."
 
 consul_clients=$(consul members | grep alive | wc -l)
 if [ $consul_clients -ne 4 ]; then

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-1
@@ -1,5 +1,8 @@
 #!/bin/bash -l
 
+echo 'shopt -s histappend' >> /home/nomad/.bashrc
+echo 'PROMPT_COMMAND="history -a;$PROMPT_COMMAND"' >> /home/nomad/.bashrc
+
 # Write Nomad Client 1 Config
 cat <<-EOF > /etc/nomad.d/nomad-client1.hcl
 # Setup data dir
@@ -37,10 +40,16 @@ cat <<-EOF > /etc/consul.d/consul-client1.json
 }
 EOF
 
+# Start Consul
 systemctl start consul
 
+# Sleep
 sleep 15
 
+# Start Nomad
 systemctl start nomad
+
+# Set the working directory
+set-workdir /home/nomad
 
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-2
@@ -1,5 +1,8 @@
 #!/bin/bash -l
 
+echo 'shopt -s histappend' >> /home/nomad/.bashrc
+echo 'PROMPT_COMMAND="history -a;$PROMPT_COMMAND"' >> /home/nomad/.bashrc
+
 # Write Nomad Client 2 Config
 cat <<-EOF > /etc/nomad.d/nomad-client2.hcl
 # Setup data dir
@@ -37,10 +40,16 @@ cat <<-EOF > /etc/consul.d/consul-client2.json
 }
 EOF
 
+# Start Consul
 systemctl start consul
 
+# Sleep
 sleep 15
 
+# Start Nomad
 systemctl start nomad
+
+# Set the working directory
+set-workdir /home/nomad
 
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-3
@@ -1,5 +1,8 @@
 #!/bin/bash -l
 
+echo 'shopt -s histappend' >> /home/nomad/.bashrc
+echo 'PROMPT_COMMAND="history -a;$PROMPT_COMMAND"' >> /home/nomad/.bashrc
+
 # Write Nomad Client 3 Config
 cat <<-EOF > /etc/nomad.d/nomad-client3.hcl
 # Setup data dir
@@ -37,10 +40,16 @@ cat <<-EOF > /etc/consul.d/consul-client3.json
 }
 EOF
 
+# Start Consul
 systemctl start consul
 
+# Sleep
 sleep 15
 
+# Start Nomad
 systemctl start nomad
+
+# Set the working directory
+set-workdir /home/nomad
 
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-server-1
@@ -1,6 +1,10 @@
 #!/bin/bash -l
 
-mkdir /root/nomad
+mkdir /home/nomad/nomad
+chown -R nomad:nomad /home/nomad/nomad
+
+echo 'shopt -s histappend' >> /home/nomad/.bashrc
+echo 'PROMPT_COMMAND="history -a;$PROMPT_COMMAND"' >> /home/nomad/.bashrc
 
 # Write Nomad Server 1 Config
 cat <<-EOF > /etc/nomad.d/nomad-server1.hcl
@@ -23,7 +27,7 @@ consul {
 EOF
 
 # Write Copy of Nomad Server 1 Config
-cat <<-EOF > /root/nomad/nomad-server1.hcl
+cat <<-EOF > /home/nomad/nomad/nomad-server1.hcl
 # Setup data dir
 data_dir = "/tmp/nomad/server1"
 
@@ -60,7 +64,7 @@ cat <<-EOF > /etc/consul.d/consul-server1.json
 EOF
 
 # Write Copy of Consul Server 1 Config
-cat <<-EOF > /root/nomad/consul-server1.json
+cat <<-EOF > /home/nomad/nomad/consul-server1.json
 {
   "server": true,
   "ui": true,
@@ -77,7 +81,7 @@ cat <<-EOF > /root/nomad/consul-server1.json
 EOF
 
 # Write Nomad Client 1 Config
-cat <<-EOF > /root/nomad/nomad-client1.hcl
+cat <<-EOF > /home/nomad/nomad/nomad-client1.hcl
 # Setup data dir
 data_dir = "/tmp/nomad/client1"
 
@@ -96,7 +100,7 @@ consul {
 EOF
 
 # Write Consul Client 1 Config
-cat <<-EOF > /root/nomad/consul-client1.json
+cat <<-EOF > /home/nomad/nomad/consul-client1.json
 {
   "ui": true,
   "log_level": "INFO",
@@ -114,7 +118,7 @@ cat <<-EOF > /root/nomad/consul-client1.json
 EOF
 
 # Write Nomad Client 2 Config
-cat <<-EOF > /root/nomad/nomad-client2.hcl
+cat <<-EOF > /home/nomad/nomad/nomad-client2.hcl
 # Setup data dir
 data_dir = "/tmp/nomad/client2"
 
@@ -133,7 +137,7 @@ consul {
 EOF
 
 # Write Consul Client 2 Config
-cat <<-EOF > /root/nomad/consul-client2.json
+cat <<-EOF > /home/nomad/nomad/consul-client2.json
 {
   "ui": true,
   "log_level": "INFO",
@@ -151,7 +155,7 @@ cat <<-EOF > /root/nomad/consul-client2.json
 EOF
 
 # Write Nomad Client 3 Config
-cat <<-EOF > /root/nomad/nomad-client3.hcl
+cat <<-EOF > /home/nomad/nomad/nomad-client3.hcl
 # Setup data dir
 data_dir = "/tmp/nomad/client3"
 
@@ -170,7 +174,7 @@ consul {
 EOF
 
 # Write Consul Client 3 Config
-cat <<-EOF > /root/nomad/consul-client3.json
+cat <<-EOF > /home/nomad/nomad/consul-client3.json
 {
   "ui": true,
   "log_level": "INFO",
@@ -187,12 +191,19 @@ cat <<-EOF > /root/nomad/consul-client3.json
 }
 EOF
 
+# Start Consul
 systemctl start consul
 
+# Sleep
 sleep 15
 
+# Start Nomad
 systemctl start nomad
 
-sleep 30
+# Sleep
+sleep 45
+
+# Set the working directory
+set-workdir /home/nomad/nomad
 
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-1
@@ -1,10 +1,7 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
-
-# Run nomad node status
-nomad node status
 
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-2
@@ -1,10 +1,7 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
-
-# Run nomad node status
-nomad node status
 
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-client-3
@@ -1,10 +1,7 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
-
-# Run nomad node status
-nomad node status
 
 exit 0

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/solve-nomad-server-1
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
 #Enable bash history
-HISTFILE=/root/.bash_history
+HISTFILE=/home/nomad/.bash_history
 set -o history
 
 # Run consul members


### PR DESCRIPTION
The nomad enterprisd binary is now protected from exfiltration even though the track is public.
The binary is in /usr/local/bin and can only be executed, not read or written.
Additionally, the nomad user can only use `su` to run `systemctl` to restart Nomad. It cannot use `sudo su -` to become root and cannot scp the nomad binary to an external server.

All challenges are run as the nomad user.