### PR TITLE
update to Nomad 0.11.2 in Intro Nomad workshop

### DIFF
--- a/instruqt-tracks/nomad-basics/config.yml
+++ b/instruqt-tracks/nomad-basics/config.yml
@@ -1,6 +1,6 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-basics/track.yml
+++ b/instruqt-tracks/nomad-basics/track.yml
@@ -28,7 +28,7 @@ challenges:
     ```
     nomad version
     ```
-    You should see "Nomad v0.10.2".
+    You should see "Nomad v0.11.2".
 
     You can also see the list of all Nomad CLI commands:
     ```
@@ -207,7 +207,7 @@ challenges:
     ```
     curl --data @payload.json http://localhost:4646/v1/jobs | jq
     ```
-    The JSON data returned will include a job index, and evaluation ID, and other information.
+    The JSON data returned will include a job index, an evaluation ID, and other information.
 
     For more information regarding creating jobs using Nomad's HTTP API, refer to https://www.nomadproject.io/api/jobs.html#create-job
 
@@ -231,7 +231,7 @@ challenges:
     ```
     curl http://localhost:4646/v1/job/redis/summary | jq
     ```
-    The JSON response should show that no jobs are currently running and that the number of complete jobs has increased by 1.
+    The JSON response should show that no allocations are currently running and that the number of complete allocations has increased by 1.
   notes:
   - type: text
     contents: |-
@@ -248,4 +248,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "5012004696476575306"
+checksum: "1584290427368761215"

--- a/instruqt-tracks/nomad-monitoring/add-web-server/check-nomad-server
+++ b/instruqt-tracks/nomad-monitoring/add-web-server/check-nomad-server
@@ -8,9 +8,6 @@ grep -q "nomad job run webserver.nomad" /root/.bash_history || fail-message "You
 # Check that the status of the webserver job was checked
 grep -q "nomad job status webserver" /root/.bash_history || fail-message "You haven't checked the status of the webserver job yet."
 
-# Check that the prometheus2.nomad job was re-run
-grep -q "nomad job run prometheus2.nomad" /root/.bash_history || fail-message "You haven't re-run the prometheus2.nomad job yet."
-
 # Check that the webserver job was stopped
 grep -q "nomad job stop webserver" /root/.bash_history || fail-message "You haven't stopped the webserver job yet."
 

--- a/instruqt-tracks/nomad-monitoring/add-web-server/solve-nomad-server
+++ b/instruqt-tracks/nomad-monitoring/add-web-server/solve-nomad-server
@@ -13,9 +13,6 @@ nomad job run webserver.nomad
 # Check the status of the webserver job
 nomad job status webserver
 
-# Re-run the prometheus2.nomad job
-nomad job run prometheus2.nomad
-
 # Stop the webserver job
 nomad job stop webserver
 

--- a/instruqt-tracks/nomad-monitoring/config.yml
+++ b/instruqt-tracks/nomad-monitoring/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-server:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-3:8500

--- a/instruqt-tracks/nomad-monitoring/track.yml
+++ b/instruqt-tracks/nomad-monitoring/track.yml
@@ -6,9 +6,9 @@ teaser: Monitor a Nomad cluster and jobs with Prometheus.
 description: |-
   The Nomad client and server agents collect runtime [telemetry](https://www.nomadproject.io/docs/telemetry/index.html). Operators can use this data to gain real-time visibility into their Nomad clusters and improve performance. Additionally, Nomad operators can set up monitoring and alerting against these metrics and export the metrics to tools like Prometheus, Grafana, Graphite, DataDog, and Circonus.
 
-  This track will guide you through implementing the [Using Prometheus to Monitor Nomad Metrics](https://www.nomadproject.io/guides/operations/monitoring-and-alerting/prometheus-metrics.html) guide.
+  This track will guide you through implementing the [Using Prometheus to Monitor Nomad Metrics](https://learn.hashicorp.com/nomad/operating-nomad/prometheus-metrics) guide.
 
-  Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics), [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster), [Nomad Multi-Server Cluster](https://instruqt.com/hashicorp/tracks/nomad-multi-server-cluster), and [Nomad Access Control Lists (ACLs)](https://instruqt.com/hashicorp/tracks/nomad-acls) tracks.
+  Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics), [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster), and the [Nomad Multi-Server Cluster](https://instruqt.com/hashicorp/tracks/nomad-multi-server-cluster) tracks.
 icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
 tags:
 - Nomad
@@ -67,7 +67,7 @@ challenges:
     ```
     nomad job status fabio | grep -A 5 Allocations
     ```
-    This should return something like this:
+    This should return something like this:<br>
     `
     Allocations
     ID        Node ID   Task Group  Version  Desired  Status   Created     Modified
@@ -96,7 +96,7 @@ challenges:
     ```
     nomad job run prometheus1.nomad
     ```
-    This should return something like this:
+    This should return something like this:<br>
     `
     ==> Monitoring evaluation "bdef8e9d"
     Evaluation triggered by job "prometheus"
@@ -110,7 +110,7 @@ challenges:
     ```
     nomad job status prometheus | grep -A 5 Allocations
     ```
-    This should return something like this:
+    This should return something like this:<br>
     `
     Allocations
     ID        Node ID   Task Group  Version  Desired  Status   Created     Modified
@@ -130,7 +130,7 @@ challenges:
     * Note that you can click the rectangular icon next to the refresh icon to hide and redisplay the assignment in order to see the results more easily.
     * The value of the `fabio` job is `3` since it is using the [system](https://www.nomadproject.io/docs/schedulers.html#system) scheduler type and we are running three Nomad clients in our demo cluster.
     * The value of our `prometheus` job is `1` since we only deployed one instance of it.
-    * To see what this looks like, visit this [page](https://www.nomadproject.io/assets/images/running-jobs-564b55df.png).
+    * To see what this looks like, visit this [page](https://learn.hashicorp.com/img/nomad/operating-nomad/running-jobs.png).
     * To see the description of other metrics, visit the [telemetry](https://www.nomadproject.io/docs/configuration/telemetry.html) section of the Nomad documentation.
 
     If you go back to the "Fabio" tab and click the Instruqt refresh icon, you will now see the "prometheus" service in the routing table.  (Note that you cannot visit it using the URL in the "Dest" column because Instruqt will not allow access to the Prometheus UI on the "Fabio" tab.)
@@ -143,7 +143,7 @@ challenges:
 
       Additionally, Nomad operators can set up monitoring and alerting against these metrics and export the metrics to tools like Prometheus, Grafana, Graphite, DataDog, and Circonus.
 
-      This track will guide you through implementing the [Using Prometheus to Monitor Nomad Metrics](https://www.nomadproject.io/guides/operations/monitoring-and-alerting/prometheus-metrics.html) guide.
+      This track will guide you through implementing the [Using Prometheus to Monitor Nomad Metrics](https://learn.hashicorp.com/nomad/operating-nomad/prometheus-metrics) guide.
   - type: text
     contents: |-
       The setup scripts for this track have configured 4 VMs running Nomad and Consul agents. One is functioning as a server while the other 3 are functioning as clients, both with regard to Nomad and to Consul.
@@ -315,21 +315,14 @@ challenges:
     `<br>
     If you would like to see the full job status, you can leave off the `grep` command.
 
-    ## Re-run the Prometheus Job
-    At this point, re-run your `prometheus` job on the "Server" tab:
-    ```
-    nomad job run prometheus2.nomad
-    ```
-    This will return results similar to what you've seen when running other jobs.
-
     ## Inspect Prometheus Targets and Alerts
     Please do the following steps on the "Prometheus" tab. (Note that we are now only showing one tab for it.)
     * Select Status -> Targets.
     * You will see `webserver` and `alertmanager` appear in your list of targets.
-    * To see what this looks like, visit this [page](https://www.nomadproject.io/assets/images/new-targets-7e2bcd93.png).
+    * To see what this looks like, visit this [page](https://learn.hashicorp.com/img/nomad/operating-nomad/new-targets.png).
     * Select the "Alerts" tab of the Prometheus UI.
     * Note the alert that we configured for the web server. No alerts are active because our web server is running.
-    * To see what this looks like, visit this [page](https://www.nomadproject.io/assets/images/alerts-ee875c5e.png).
+    * To see what this looks like, visit this [page](https://learn.hashicorp.com/img/nomad/operating-nomad/alerts.png).
 
     ## Stop the Web Server to See Alerts
     Next, please stop your webserver on the "Server" tab:
@@ -340,11 +333,11 @@ challenges:
     Now, let's see what Prometheus is showing on the "Prometheus" tab.
     * Select the "Alerts" tab of the Prometheus UI (even if it is already selected).
     * Note that we now have an active "Webserver down" alert.
-    * To see what this looks like, visit this [page](https://www.nomadproject.io/assets/images/active-alert-cfcc7e45.png).
+    * To see what this looks like, visit this [page](https://learn.hashicorp.com/img/nomad/operating-nomad/active-alert.png).
 
     Verify that Alertmanager has received this alert as well on the "Alertmanager" tab.
     * You should see that Alertmanager has received the alert and is showing it as `alertname="Webserver down"`. (You will probably want to click the rectangular Instruqt icon to temporarily hide this assignment to get the Alertmananger spread out horizontally more.)
-    * To see what this looks like, visit this [page](https://www.nomadproject.io/assets/images/alertmanager-webui-612ce20c.png).
+    * To see what this looks like, visit this [page](https://learn.hashicorp.com/img/nomad/operating-nomad/alertmanager-webui.png).
 
     ## Restart the Web Server
     Please restart the `webserver` job on the "Server" tab:
@@ -396,4 +389,4 @@ challenges:
     port: 9999
   difficulty: basic
   timelimit: 600
-checksum: "18340852418893460676"
+checksum: "16346210181371618422"

--- a/instruqt-tracks/nomad-multi-server-cluster/config.yml
+++ b/instruqt-tracks/nomad-multi-server-cluster/config.yml
@@ -1,31 +1,31 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-server-2
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-2:8500
   machine_type: n1-standard-1
 - name: nomad-server-3
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-3:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500

--- a/instruqt-tracks/nomad-multi-server-cluster/track.yml
+++ b/instruqt-tracks/nomad-multi-server-cluster/track.yml
@@ -103,7 +103,7 @@ challenges:
   notes:
   - type: text
     contents: |-
-      This track will show you how to bootstrap a Nomad cluster that has three servers and two clients in two different ways. You will also learn how easy it is to register Nomad tasks as Consul services and secure them with Nomad's native integration with [Consul Connect](https://learn.hashicorp.com/nomad/consul-integration/nomad-connect-acl).
+      This track will show you how to bootstrap a Nomad cluster that has three servers and two clients in two different ways. You will also learn how easy it is to register Nomad tasks as Consul services and secure them with Nomad's native integration with [Consul Connect](https://www.nomadproject.io/docs/integrations/consul-connect/).
 
       In this first challenge, you will bootstrap the Nomad cluster using manual clustering.
 
@@ -352,7 +352,7 @@ challenges:
 
     As you watch the app, you should see the counter climb.
 
-    You can also look at the tasks associated proxies in both the Nomad and the Consul UIs.
+    You can also look at the tasks associated with proxies in both the Nomad and the Consul UIs.
 
     Congratulations on completing the Nomad Multi-Server Cluster track!
   notes:
@@ -401,4 +401,4 @@ challenges:
     port: 9002
   difficulty: basic
   timelimit: 1200
-checksum: "13477204803359411370"
+checksum: "1464619900613205445"

--- a/instruqt-tracks/nomad-simple-cluster/config.yml
+++ b/instruqt-tracks/nomad-simple-cluster/config.yml
@@ -1,14 +1,14 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-4-0
+  image: instruqt-hashicorp/hashistack-0-6-2
   shell: /bin/bash -l
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-simple-cluster/modifying-a-job/solve-nomad-server
+++ b/instruqt-tracks/nomad-simple-cluster/modifying-a-job/solve-nomad-server
@@ -4,6 +4,9 @@
 echo -e "cd nomad" >> /root/.bash_history
 cd nomad
 
+# Change count to 3 in example.nomad
+sed -i 's/task/count = 3\n\t\ttask/g' example.nomad
+
 # Plan the job
 echo -e "nomad job plan example.nomad" >> /root/.bash_history
 nomad job plan example.nomad > planjob.log

--- a/instruqt-tracks/nomad-simple-cluster/run-your-first-job/solve-nomad-server
+++ b/instruqt-tracks/nomad-simple-cluster/run-your-first-job/solve-nomad-server
@@ -4,9 +4,6 @@
 echo -e "cd nomad" >> /root/.bash_history
 cd nomad
 
-# Change count to 3 in example.nomad
-sed -i 's/task/count = 3\n\t\ttask/g' example.nomad
-
 # Run the job
 echo -e "nomad job run example.nomad" >> /root/.bash_history
 nomad job run example.nomad > runjob.log

--- a/instruqt-tracks/nomad-simple-cluster/track.yml
+++ b/instruqt-tracks/nomad-simple-cluster/track.yml
@@ -191,7 +191,7 @@ challenges:
     ```
     This will show the ID of the job ("example"), the Status ("running"), the datacenters it is running in, and some other high-level information.  It will then show a summary of the job's task groups, indicating how many are queued, started, running, failed, completed, and lost.
 
-    This is followed by information about the latest deployment of the job and by information about the job's allocations. You should see that one allocation is running.
+    This is followed by information about the latest deployment of the job and by information about the job's allocations. You should see that one allocation is running and healthy.
 
     Next, get more information about the evaluation by running:<br>
     `nomad eval status <EvaluationID>`<br>
@@ -266,9 +266,9 @@ challenges:
     ```
     You will see that the scheduler detected the change in count and informs us that it will cause 2 new allocations to be created. The in-place update that will occur pushes the update of the job specification to the existing allocation but will not cause any service interruption.
 
-    After running the plan, check if the dry-run is successful to see if there's enough resources for the changes. If it completes, then we're ready to apply the updates!
+    The dry-run indicates that there are enough resources for the modified job to be run by returning "All tasks successfully allocated."
 
-    Do that by running the following:<br>
+    Run the modified job with the following command:<br>
     `nomad job run -check-index <job_modify_index> example.nomad`<br>
     where <job_modify_index\> is the job modify index returned by the `nomad job plan` command.
 
@@ -276,7 +276,7 @@ challenges:
 
     After running the job, we can see that 2 additional allocations were created as desired.
 
-    Look at the job in the Nomad UI tab to verify that the additional allocations were deployed. You should see 3 allocations in the "Running" status. Also look at both clients in the Nomad UI and verify that one of them has 2 allocations and that the other has 1 allocation.
+    Look at the job in the Nomad UI tab to verify that the additional allocations were deployed. You should see 3 healthy allocations. Also look at both clients in the Nomad UI and verify that one of them has 2 allocations and that the other has 1 allocation.
 
     To stop the job and de-allocate all the redis docker containers, run the following command on the "Server" tab:
     ```
@@ -287,7 +287,8 @@ challenges:
     ```
     nomad status example
     ```
-    Inspect the following properties:
+    <br>
+    Please do the following:
 
     1. Check that the Status attribute of the job is marked as "dead (stopped)".
     2. Under the Allocations section, verify that all three allocations have the "complete" status.
@@ -314,4 +315,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "11842144462749863460"
+checksum: "7085498699051331824"


### PR DESCRIPTION
I updated the image used by the 4 Instruqt tracks of the Intro to Nomad workshop to use Nomad 0.11.2.

I also fixed various links in the 4 tracks, especially in nomad-monitoring.
In that track, I also removed an unnecessary instruction to run the prometheus job a third time.