### PR TITLE
use 0.11.3 for Consul Connect track

### DIFF
--- a/instruqt-tracks/nomad-consul-connect/config.yml
+++ b/instruqt-tracks/nomad-consul-connect/config.yml
@@ -1,19 +1,19 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-6-1
+  image: instruqt-hashicorp/hashistack-0-6-3
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-6-1
+  image: instruqt-hashicorp/hashistack-0-6-3
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-6-1
+  image: instruqt-hashicorp/hashistack-0-6-3
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500

--- a/instruqt-tracks/nomad-consul-connect/track.yml
+++ b/instruqt-tracks/nomad-consul-connect/track.yml
@@ -28,7 +28,7 @@ challenges:
   assignment: |-
     In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-    The cluster is running 1 Nomad/Consul server and 2 Nomad/Consul clients. They are using Nomad 0.11.1 and Consul 1.7.2.
+    The cluster is running 1 Nomad/Consul server and 2 Nomad/Consul clients. They are using Nomad 0.11.3 and Consul 1.7.4.
 
     First, verify that all 3 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
     ```
@@ -155,4 +155,4 @@ challenges:
     port: 9002
   difficulty: basic
   timelimit: 1200
-checksum: "16920564523052373855"
+checksum: "4537806110767198092"


### PR DESCRIPTION
Created new VM image, hashistack-0-6-3 with Nomad 0.11.3 and Consul 1.7.4 so I could test whether unavailability of allocation logs in Nomad UI is still a problem in 0.11.3.  Sadly, it still is.