### PR TITLE
extend monitoring track, remove UI logs

### DIFF
--- a/instruqt-tracks/nomad-monitoring/track.yml
+++ b/instruqt-tracks/nomad-monitoring/track.yml
@@ -183,7 +183,7 @@ challenges:
     hostname: nomad-client-3
     port: 9999
   difficulty: basic
-  timelimit: 600
+  timelimit: 1200
 - slug: add-alertmanager
   id: aaqomh65hrcz
   type: challenge
@@ -279,7 +279,7 @@ challenges:
     hostname: nomad-client-1
     port: 9999
   difficulty: basic
-  timelimit: 600
+  timelimit: 1200
 - slug: add-web-server
   id: wzwlz6v21qqr
   type: challenge
@@ -388,5 +388,5 @@ challenges:
     path: /alertmanager
     port: 9999
   difficulty: basic
-  timelimit: 600
-checksum: "16346210181371618422"
+  timelimit: 1200
+checksum: "5542512654765717847"

--- a/instruqt-tracks/nomad-simple-cluster/track.yml
+++ b/instruqt-tracks/nomad-simple-cluster/track.yml
@@ -205,7 +205,9 @@ challenges:
     `nomad alloc logs <AllocationID> redis`<br>
     where <AllocationID\> is the same allocation ID you used for the last command.  You will see the complete logs from the Redis Docker container that was launched.
 
-    We encourage you to also look at the status of the job and its allocation and the task log in the Nomad UI.  To do this, click on the "example" job, scroll down, select the allocation, scroll down, click "redis", and select the "Logs" tab.
+    Note that while allocation logs can normally be viewed in the Nomad UI, this is blocked in the Instruqt environment.
+
+    We encourage you to also look at the status of the job and its allocation in the Nomad UI.
 
     You can also look at deployment details on the "Deployments" tab, inspect allocations on the "Allocations" tab, and see evaluation details on the "Evaluations" tab.
 
@@ -315,4 +317,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "7085498699051331824"
+checksum: "8653733042126027712"


### PR DESCRIPTION
The Nomad Monitoring track had a total timelimit of 30 minutes, but some people needed more. I doubled to 60 minutes.
I also removed references to examining allocation logs in the Nomad UI from the Nomad Simple Cluster track because that does not work inside Instruqt.