### PR TITLE
expand windows on nomad, use new image in consul track

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -548,6 +548,46 @@ jobs:
               echo "Instruqt track test failed three times."
               exit 1
             fi
+  instruqt-test-nomad-on-windows:
+    docker:
+      - image: ubuntu:latest
+    steps:
+      - checkout
+      - run:
+          name: Run Instruqt Test
+          command: |
+            VERSION=$INSTRUQT_VERSION
+            apt -y update
+            apt -y install wget unzip
+            wget https://github.com/instruqt/cli/releases/download/${VERSION}/instruqt-linux-${VERSION}.zip -O /tmp/instruqt.zip
+            cd /tmp
+            unzip instruqt.zip
+            cp instruqt /usr/local/bin/instruqt
+            chmod +x /usr/local/bin/instruqt
+            echo "yes" | instruqt version
+            RETVAL=$?
+            if [[ $RETVAL -ne 0 ]]; then
+              echo "Instruqt is not installed correctly."
+              exit 1
+            else
+              echo "Instruqt is installed and updated to most recent version."
+            fi
+            cd /root/project/instruqt-tracks/nomad-on-windows
+            echo "Running instruqt track push..."
+            instruqt track push --force
+            echo "Running instruqt track test..."
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 60
+            done
+            if [ $n -ge 3 ]; then
+              echo "Instruqt track test failed three times."
+              exit 1
+            fi
 workflows:
   version: 2
   build-and-deploy:
@@ -634,6 +674,12 @@ workflows:
           filters:
             branches:
               only: master
+      - instruqt-test-nomad-on-windows:
+          requires:
+            - instruqt-validate
+          filters:
+            branches:
+              only: master
   nightly-build:
     triggers:
       - schedule:
@@ -681,5 +727,8 @@ workflows:
           requires:
             - instruqt-validate
       - instruqt-test-nomad-governance:
+          requires:
+            - instruqt-validate
+      - instruqt-test-nomad-on-windows:
           requires:
             - instruqt-validate

--- a/instruqt-tracks/nomad-consul-connect/config.yml
+++ b/instruqt-tracks/nomad-consul-connect/config.yml
@@ -1,19 +1,19 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-6-3
+  image: instruqt-hashicorp/hashistack-enterprise-0-8-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-6-3
+  image: instruqt-hashicorp/hashistack-enterprise-0-8-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-6-3
+  image: instruqt-hashicorp/hashistack-enterprise-0-8-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500

--- a/instruqt-tracks/nomad-consul-connect/track.yml
+++ b/instruqt-tracks/nomad-consul-connect/track.yml
@@ -18,6 +18,7 @@ developers:
 - roger@hashicorp.com
 private: false
 published: true
+show_timer: true
 challenges:
 - slug: verify-nomad-cluster-health
   id: y96veofixdxn
@@ -28,7 +29,7 @@ challenges:
   assignment: |-
     In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-    The cluster is running 1 Nomad/Consul server and 2 Nomad/Consul clients. They are using Nomad 0.11.3 and Consul 1.7.4.
+    The cluster is running 1 Nomad/Consul server and 2 Nomad/Consul clients. They are using Nomad 0.12.3 and Consul 1.8.3.
 
     First, verify that all 3 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
     ```
@@ -70,7 +71,7 @@ challenges:
     hostname: nomad-server-1
     port: 4646
   difficulty: basic
-  timelimit: 300
+  timelimit: 900
 - slug: nomad-and-consul-connect
   id: qtu9dyfttayl
   type: challenge
@@ -154,6 +155,5 @@ challenges:
     hostname: nomad-client-2
     port: 9002
   difficulty: basic
-  timelimit: 1200
-checksum: "11396627031001395493"
-show_timer: true
+  timelimit: 2700
+checksum: "10462144364891199349"

--- a/instruqt-tracks/nomad-on-windows/run-nomad-jobs/check-cloud-client
+++ b/instruqt-tracks/nomad-on-windows/run-nomad-jobs/check-cloud-client
@@ -1,0 +1,24 @@
+#!/bin/bash -l
+
+set -e
+
+# Get Nomad job status
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad job status' > nomad_jobs.txt
+
+# Find running jobs
+running_jobs=$(cat nomad_jobs.txt | grep running | wc -l)
+
+# Check running jobs
+if [ $running_jobs -ne 3 ]; then
+  fail-message "'nomad job status' does not show 3 running Nomad jobs."
+fi
+
+# Find dead jobs (the batch one)
+dead_jobs=$(cat nomad_jobs.txt | grep dead | wc -l)
+
+# Check dead jobs
+if [ $dead_jobs -ne 1 ]; then
+  fail-message "'nomad job status' does not show 1 dead Nomad job (from running 'nomad job dispatch'against the batch job) as expected."
+fi
+
+exit 0

--- a/instruqt-tracks/nomad-on-windows/run-nomad-jobs/setup-cloud-client
+++ b/instruqt-tracks/nomad-on-windows/run-nomad-jobs/setup-cloud-client
@@ -1,0 +1,177 @@
+#!/bin/bash -l
+
+# Write out jenkins.nomad job to cloud-client
+cat <<-EOF > /root/nomad/jenkins.nomad
+job "jenkins" {
+  type = "service"
+  datacenters = ["dc1"]
+
+  group "web" {
+    count = 1
+
+    ephemeral_disk {
+      migrate = true
+      size    = "110"
+      sticky  = true
+    }
+
+    task "frontend" {
+      driver = "java"
+
+      env {
+        # Use ephemeral storage for Jenkins data.
+        JENKINS_HOME = "/alloc/data"
+        JENKINS_SLAVE_AGENT_PORT = "\${NOMAD_PORT_slave}"
+      }
+
+      config {
+        jar_path    = "local/jenkins.war"
+        jvm_options = ["-Xmx768m", "-Xms384m"]
+        args        = ["--httpPort=\${NOMAD_PORT_http}"]
+      }
+
+      artifact {
+        source = "http://ftp-chi.osuosl.org/pub/jenkins/war/2.253/jenkins.war"
+        options {
+          checksum = "sha256:d99c51292349af4934ab9769ba9ef2ed9ab9a8b118ff601aaabf1d5bf2a4e6a1"
+        }
+      }
+
+      service {
+        port = "http"
+        name = "jenkins"
+
+        check {
+          type     = "http"
+          path     = "/login"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      resources {
+        cpu    = 2000 # MHz
+        memory = 1024 # MB
+        network {
+          mbits = 100
+          port "http" {}
+          port "slave" {}
+        }
+      }
+    }
+  }
+}
+EOF
+
+# SCP jenkins.nomad to nomad-server-1
+sshpass -e scp /root/nomad/jenkins.nomad hashistack@$nomad_server_ip:c:\\Users\\hashistack\\nomad\\jenkins.nomad
+
+# Write the iss.nomad job to cloud-client
+cat <<-EOF > /root/nomad/iis.nomad
+job "iis" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  constraint {
+    attribute = "\${attr.kernel.name}"
+    value = "windows"
+  }
+
+  group "iis" {
+    count = 1
+
+    network {
+      port "http" {
+        static = 8000
+        to = 80
+      }
+    }
+
+    service {
+      name = "iis"
+      tags = ["windows", "iis"]
+      port = "http"
+      check_restart {
+        grace = "600s"
+      }
+    }
+
+    task "iis" {
+      driver = "docker"
+
+      config {
+        image = "https://mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"
+        ports = ["http"]
+      }
+
+      resources {
+        cpu = 2000 # Mhz
+        memory = 2048 # MB
+      }
+    }
+  }
+}
+EOF
+
+# SCP iis.nomad to nomad-server-1
+sshpass -e scp /root/nomad/iis.nomad hashistack@$nomad_server_ip:c:\\Users\\hashistack\\nomad\\iis.nomad
+
+# Write batchjob.nomad to cloud-client
+cat <<-EOF > /root/nomad/batchjob.nomad
+job "batchjob" {
+  datacenters = ["dc1"]
+  type = "batch"
+
+  constraint {
+    attribute = "\${attr.kernel.name}"
+    value     = "windows"
+  }
+
+  # to dispatch this job use `nomad job dispatch -meta TTL=60 batchjob`
+  parameterized {
+    #TTL is the amount of time this batch job will run for before it gets terminated
+    meta_required = ["TTL"]
+  }
+
+  group "dotnet-batch" {
+    count = 1
+
+    task "callexe" {
+
+      driver = "raw_exec"
+
+      config {
+        command = "powershell.exe"
+        args = ["local/runbatch.ps1   \${NOMAD_META_TTL}"]
+      }
+
+      artifact {
+        source   = "git::https://github.com/GuyBarros/dotnet-batch-service"
+        destination = "local/repo"
+      }
+
+      template {
+        data = <<EOH
+        param(
+        \$TTL
+        )
+        start local/repo/dotnet-batch-service.exe
+        ping 127.0.0.1 -n \$TTL
+        taskkill /im dotnet-batch-service.exe /f
+        EOH
+        destination = "local/runbatch.ps1"
+      }
+
+      resources {
+        cpu    = 500 # MHz
+        memory = 512 # MB
+      }
+    }
+  }
+}
+EOF
+
+# SCP batchjob.nomad to nomad-server-1
+sshpass -e scp /root/nomad/batchjob.nomad hashistack@$nomad_server_ip:c:\\Users\\hashistack\\nomad\\batchjob.nomad
+
+exit 0

--- a/instruqt-tracks/nomad-on-windows/run-nomad-jobs/solve-cloud-client
+++ b/instruqt-tracks/nomad-on-windows/run-nomad-jobs/solve-cloud-client
@@ -1,0 +1,28 @@
+#!/bin/bash -l
+
+#Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+# Sleep
+sleep 30
+
+# Run Windows IIS Job
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad job run c:\Users\hashistack\nomad\iis.nomad'
+
+# Run Jenkins Job
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad job run c:\Users\hashistack\nomad\jenkins.nomad'
+
+# Run DotNet Batch Job
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad job run batchjob.nomad'
+
+# Sleep
+sleep 30
+
+# Dispatch an instance of the batchjob
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad job dispatch -meta TTL=120 batchjob'
+
+# Sleep
+sleep 150
+
+exit 0

--- a/instruqt-tracks/nomad-on-windows/track.yml
+++ b/instruqt-tracks/nomad-on-windows/track.yml
@@ -12,8 +12,9 @@ tags:
 owner: hashicorp
 developers:
 - roger@hashicorp.com
-private: true
+private: false
 published: true
+show_timer: true
 challenges:
 - slug: verify-nomad-cluster-health
   id: gkyrdoguwa1q
@@ -28,7 +29,9 @@ challenges:
 
     You can see the VMs that were created for you by clicking the icon with 3 horizontal bars in the upper left corner of the console, selecting the "Compute Engine" menu, and then selecting "VM Instances".
 
-    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 0.11.0 and Consul 1.7.2. These VMs have been created in a GCP project within this Instruqt track.
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 0.12.3 and Consul 1.8.3. These VMs have been created in a GCP project within this Instruqt track.
+
+    Additionally, OpenJDK 11 has been installed for you so that you can use Nomad's Java driver if desired.
 
     First, determine the public IP of your Nomad server by running this command on the "Google CLI" tab:
     ```
@@ -41,7 +44,7 @@ challenges:
 
     SSH to the Nomad server with this command:
     ```
-    sshpass -e ssh nomad@$nomad_server_ip
+    sshpass -e ssh hashistack@$nomad_server_ip
     ```
 
     Next, verify that all 4 Consul agents are running and connected to the cluster by running this command on the "Google CLI" tab:
@@ -62,13 +65,31 @@ challenges:
     ```
     You should see 3 Nomad clients with the "ready" status.
 
-    Type `exit` to quit the SSH session.
+    You can validate that Java has been installed by on the server by running `java -version`. This will return the version of Java that was installed.
+
+    You can validate that Docker is available on the server by running `docker ps`. This should show that there are currently no Docker containers running. If you get an error, use the process described below to fix Docker on the Nomad server.
+
+    You can also verify that Java and Docker are available on all 3 Nomad clients by inspecting them in the Nomad UI. The Driver Status section of each of them should show small green boxes with "Healthy" next to them. You should also see that the Raw Exec driver is enabled and healthy on all 3 clients.
+
+    Type `exit` to quit the SSH session for the Nomad server.
+
+    If the Docker driver was not healthy on any of the Nomad clients, you can fix this by doing the following:
+      * SSH to that Nomad client with `sshpass -e ssh hashistack@$nomad_client_<n>_ip` where <n\> is the number of the Nomad client that did not have a healthy Docker driver.
+      * On that Nomad client, run `sc start Docker` to start Docker. If this is successful, you should see multiple lines of output, none of which contain errors.
+      * Run `docker ps` to test that you can now list running Docker containers on this Nomad client.
+      * Check in the Nomad UI that the Docker driver is now marked Healthy for this client.
+      * Type `exit` to quit the SSH session.
+    Repeat the above steps for any other Nomad clients that do not have a healthy Docker driver. You can also fix Docker on the Nomad server with this procedure.
+
+    In the next challenge, you will run Java, Docker, and DotNet jobs on the Nomad clients.
   notes:
   - type: text
     contents: |-
-      In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
+      In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs. The cluster is running on Windows Server 2019 VMs.
 
-      The cluster is running on Windows Server 2019 VMs.
+      You will also validate that the Java, Docker, and Raw Exec drivers are enabled and healthy on all 3 Nomad clients.
+
+      In a second challenge, you will run 3 jobs on the Nomad clients, using these 3 Nomad drivers.
   tabs:
   - title: Google CLI
     type: terminal
@@ -79,6 +100,100 @@ challenges:
     path: /
     port: 80
   difficulty: basic
-  timelimit: 7200
-checksum: "2259062498856498763"
-show_timer: true
+  timelimit: 1800
+- slug: run-nomad-jobs
+  id: bsm9lcovj1to
+  type: challenge
+  title: Run Java, Docker, and DotNet Jobs
+  teaser: |
+    Run Java, Docker, and DotNet jobs on your Windows Nomad clients.
+  assignment: |-
+    ## Introduction
+    In this challenge, you will run three Nomad jobs that all deploy workload to the Nomad clients running on Windows.
+      * The first uses the [Docker Driver](https://www.nomadproject.io/docs/drivers/docker) to run Windows IIS inside a Docker container.
+      * The second uses the [Java Driver](https://www.nomadproject.io/docs/drivers/java) to run the CI/CD solution, Jenkins.
+      * The third runs a parameterized Nomad batch job that uses Nomad's [Raw Fork/Exec Driver](https://www.nomadproject.io/docs/drivers/raw_exec) to launch a compiled DotNet application.
+
+    To get started, please SSH to your Nomad server with the following command:
+    ```
+    sshpass -e ssh hashistack@$nomad_server_ip
+    ```
+
+    Navigate to the c:\Users\hashistack\nomad directory with this command:
+    ```
+    cd nomad
+    ```
+
+    ## Run Windows IIS with the Docker Driver
+    Run the Windows IIS job that uses the Docker driver with this command:
+    ```
+    nomad job run iis.nomad
+    ```
+
+    Visit the Nomad UI, visit the Jobs screen, select the `iis` job and verify that 1 allocation becomes healthy within about 5 minutes. The Docker image is quite big, so it takes about 10 minutes for Nomad to download it.
+
+    While Nomad is downloading the IIS docker image, go ahead and run the other two jobs.
+
+    ## Run Jenkins with the Java Driver
+    Run the Jenkins job that uses the Java driver with this command:
+    ```
+    nomad job run jenkins.nomad
+    ```
+
+    Visit the Nomad UI that you launched in the first challenge, visit the Jobs screen, select the `jenkins` job and verify that 1 allocation becomes healthy within a minute or two.
+
+    You can also check the status of the Jenkins job with this command:
+    ```
+    nomad job status jenkins
+    ```
+    You might need to run that a few times before you see the healthy allocation.
+
+    ## Run a Batch Job with the Raw Exec Driver
+    The "batchjob.nomad" file contains a parameterized batch job that runs a multi-threaded Windows DotNet application that determines whether numbers are prime or not. It is run by the Raw Exec driver and runs until the time set by `TTL` parameter passed to it has passed. We will first register the job and then dispatch a parameterized instance of it.
+
+    Register the job with this command:
+    ```
+    nomad job run batchjob.nomad
+    ```
+
+    Visit the Nomad UI, visit the Jobs screen, select the `batchjob` job, and verify that it is running.
+
+    Then dispatch an instance of the batch job that will run for 120 seconds with this command:
+    ```
+    nomad job dispatch -meta TTL=120 batchjob
+    ```
+
+    Visit the Nomad UI to verify that an instance of the batchjob job has been dispatched. Then drill into the instance, the "dotnet-batch" task group, the current allocation, and the "callexe" task of the dispatched instance of the job. In the task, click on the "Files" tab, then "local", and then "repo". Open the "PrimeNumbers.txt" file to see which numbers the job has evaluated and whether they are prime numbers or not. Because the DotNet program is multi-threaded, the prime numbers will not be printed in order.
+
+    You can also look at the "stdout" section of the "logs" tab to see pinging being done by the script until the TTL is reached.
+
+    ## Verify Successful Deployment of IIS
+    Return to the `iis` job in the Nomad UI to see how that job is doing. Select the running allocation, the task group, and the task. You will hopefully see that all 5 layers of the Docker image have been download. Unfortunately, the messages after that do not really indicate how much progress is being made. But it should not take more than 10 minutes from when you started the job. If it takes 15 minutes, Nomad will consider the image download to have failed since we configured that limit in the Nomad clients.
+
+    After the task transitions to a running state, you can visit the IIS home page. But you first have to determine the public IP of the Nomad client it is running on. To do that, click on the link for the client the task is running on and then scroll down to find the external IP. (Don't use the internal/private IP.)
+
+    Once you find the IP, point a browser tab to `http://<public_ip>:8000` to view the IIS home page.
+
+    Congratulations on completing the Nomad on Windows track.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will run 3 Nomad jobs on your Windows Nomad clients.
+
+      The first job will use the Docker driver to run a Windows IIS web server.
+
+      The second job will use the Java driver to run the CI/CD solution, Jenkins.
+
+      The third job will use the Raw Exec driver to run a DotNet application as a batch job.
+  tabs:
+  - title: Google CLI
+    type: terminal
+    hostname: cloud-client
+  - title: Google Console Link
+    type: service
+    hostname: cloud-client
+    path: /
+    port: 80
+  difficulty: basic
+  timelimit: 1800
+checksum: "17518454912274917958"

--- a/instruqt-tracks/nomad-on-windows/verify-nomad-cluster-health/check-cloud-client
+++ b/instruqt-tracks/nomad-on-windows/verify-nomad-cluster-health/check-cloud-client
@@ -2,21 +2,21 @@
 
 set -e
 
-sshpass -e ssh nomad@$nomad_server_ip 'consul members' > consul_members.txt
+sshpass -e ssh hashistack@$nomad_server_ip 'consul members' > consul_members.txt
 consul_members=$(cat consul_members.txt | grep alive | wc -l)
 
 if [ $consul_members -ne 4 ]; then
   fail-message "'consul members' does not show 4 running Consul nodes."
 fi
 
-sshpass -e ssh nomad@$nomad_server_ip 'nomad server members' > nomad_servers.txt
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad server members' > nomad_servers.txt
 nomad_servers=$(cat nomad_servers.txt | grep alive | wc -l)
 
 if [ $nomad_servers -ne 1 ]; then
   fail-message "'nomad server members' does not show 1 running Nomad server."
 fi
 
-sshpass -e ssh nomad@$nomad_server_ip 'nomad node status' > nomad_clients.txt
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad node status' > nomad_clients.txt
 nomad_clients=$(cat nomad_clients.txt | grep ready | wc -l)
 
 if [ $nomad_clients -ne 3 ]; then

--- a/instruqt-tracks/nomad-on-windows/verify-nomad-cluster-health/setup-cloud-client
+++ b/instruqt-tracks/nomad-on-windows/verify-nomad-cluster-health/setup-cloud-client
@@ -7,16 +7,16 @@ export SSHPASS=Passw0rd!
 echo "export SSHPASS=Passw0rd!" >> /root/.bashrc
 
 # Create Nomad Server
-gcloud compute instances create nomad-server-1 --image-project=instruqt-hashicorp --image=hashistack-windows-0-6-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-1
+gcloud compute instances create nomad-server-1 --image-project=instruqt-hashicorp --image=windows-hashistack-0-8-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-1
 
 # Create Nomad Client 1
-gcloud compute instances create nomad-client-1 --image-project=instruqt-hashicorp --image=hashistack-windows-0-6-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-1
+gcloud compute instances create nomad-client-1 --image-project=instruqt-hashicorp --image=windows-hashistack-0-8-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
 
 # Create Nomad Client 2
-gcloud compute instances create nomad-client-2 --image-project=instruqt-hashicorp --image=hashistack-windows-0-6-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-1
+gcloud compute instances create nomad-client-2 --image-project=instruqt-hashicorp --image=windows-hashistack-0-8-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
 
 # Create Nomad Client 3
-gcloud compute instances create nomad-client-3 --image-project=instruqt-hashicorp --image=hashistack-windows-0-6-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-1
+gcloud compute instances create nomad-client-3 --image-project=instruqt-hashicorp --image=windows-hashistack-0-8-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
 
 # Sleep
 sleep 60
@@ -35,6 +35,9 @@ gcloud compute firewall-rules create consul-allow-inbound-wan-serf --allow tcp:8
 gcloud compute firewall-rules create nomad-allow-inbound-http --allow tcp:4646
 gcloud compute firewall-rules create nomad-allow-inbound-rpc --allow tcp:4647 --source-tags=nomad --target-tags=nomad
 gcloud compute firewall-rules create nomad-allow-inbound-serf --allow tcp:4648 --allow udp:4648 --source-tags=nomad --target-tags=nomad
+
+# Create Firewall Rule for IIS
+gcloud compute firewall-rules create iis-allow-inbound-http --allow tcp:8000
 
 # Export public IP of nomad-server-1
 export nomad_server_ip=$(gcloud compute instances list | grep nomad-server-1 | cut -d' ' -f23)
@@ -78,10 +81,10 @@ ssh-keyscan -H $nomad_client_3_ip >> ~/.ssh/known_hosts
 mkdir /root/nomad
 
 # Disable Windows firewall on all 4 VMs
-sshpass -e ssh nomad@$nomad_server_ip 'netsh advfirewall set allprofiles state off'
-sshpass -e ssh nomad@$nomad_client_1_ip 'netsh advfirewall set allprofiles state off'
-sshpass -e ssh nomad@$nomad_client_2_ip 'netsh advfirewall set allprofiles state off'
-sshpass -e ssh nomad@$nomad_client_3_ip 'netsh advfirewall set allprofiles state off'
+sshpass -e ssh hashistack@$nomad_server_ip 'netsh advfirewall set allprofiles state off'
+sshpass -e ssh hashistack@$nomad_client_1_ip 'netsh advfirewall set allprofiles state off'
+sshpass -e ssh hashistack@$nomad_client_2_ip 'netsh advfirewall set allprofiles state off'
+sshpass -e ssh hashistack@$nomad_client_3_ip 'netsh advfirewall set allprofiles state off'
 
 
 ### Server
@@ -90,9 +93,9 @@ cat <<-EOF > /root/nomad/consul-server1.json
 {
   "server": true,
   "ui": true,
-  "log_file": "c:\\\\Users\\\\nomad\\\\consul\\\\consul.log",
+  "log_file": "c:\\\\Users\\\\hashistack\\\\consul\\\\consul.log",
   "log_level": "INFO",
-  "data_dir": "c:\\\\Users\\\\nomad\\\\consul\\\\data\\\\",
+  "data_dir": "c:\\\\Users\\\\hashistack\\\\consul\\\\data\\\\",
   "node_name": "server1",
   "bind_addr": "$nomad_server_private_ip",
   "client_addr": "0.0.0.0",
@@ -101,13 +104,13 @@ cat <<-EOF > /root/nomad/consul-server1.json
 EOF
 
 # SCP Consul Config File to nomad-server-1
-sshpass -e scp /root/nomad/consul-server1.json nomad@$nomad_server_ip:c:\\Users\\nomad\\consul\\consul-server1.json
+sshpass -e scp /root/nomad/consul-server1.json hashistack@$nomad_server_ip:c:\\Users\\hashistack\\consul\\consul-server1.json
 
 # Make Consul data directory
-sshpass -e ssh nomad@$nomad_server_ip 'mkdir c:\Users\nomad\consul\data'
+sshpass -e ssh hashistack@$nomad_server_ip 'mkdir c:\Users\hashistack\consul\data'
 
 # Start Consul on Server
-sshpass -e ssh nomad@$nomad_server_ip 'sc start Consul'
+sshpass -e ssh hashistack@$nomad_server_ip 'sc start Consul'
 
 # Sleep
 sleep 15
@@ -115,7 +118,7 @@ sleep 15
 # Write Nomad Server Config
 cat <<-EOF > /root/nomad/nomad-server1.hcl
 # Setup data dir
-data_dir = "c:\\\\Users\\\\nomad\\\\nomad\\\\data\\\\"
+data_dir = "c:\\\\Users\\\\hashistack\\\\nomad\\\\data\\\\"
 
 # Give the agent a unique name.
 name = "server1"
@@ -131,25 +134,28 @@ consul {
   address = "nomad-server-1:8500"
 }
 
-log_file = "c:\\\\Users\\\\nomad\\\\nomad\\\\nomad.log"
+log_file = "c:\\\\Users\\\\hashistack\\\\nomad\\\\nomad.log"
 EOF
 
 # SCP Nomad Config File to nomad-server-1
-sshpass -e scp /root/nomad/nomad-server1.hcl nomad@$nomad_server_ip:c:\\Users\\nomad\\nomad\\nomad-server1.hcl
+sshpass -e scp /root/nomad/nomad-server1.hcl hashistack@$nomad_server_ip:c:\\Users\\hashistack\\nomad\\nomad-server1.hcl
 
 # Make Nomad data directory
-sshpass -e ssh nomad@$nomad_server_ip 'mkdir c:\Users\nomad\nomad\data'
+sshpass -e ssh hashistack@$nomad_server_ip 'mkdir c:\Users\hashistack\nomad\data'
 
 # Start Nomad on Server
-sshpass -e ssh nomad@$nomad_server_ip 'sc start Nomad'
+sshpass -e ssh hashistack@$nomad_server_ip 'sc start Nomad'
+
+# Start Docker in case it was not started
+# sshpass -e ssh hashistack@$nomad_server_ip 'sc start Docker'
 
 ### Client 1
 # Write Consul Client Config
 cat <<-EOF > /root/nomad/consul-client1.json
 {
-  "log_file": "c:\\\\Users\\\\nomad\\\\consul\\\\consul.log",
+  "log_file": "c:\\\\Users\\\\hashistack\\\\consul\\\\consul.log",
   "log_level": "INFO",
-  "data_dir": "c:\\\\Users\\\\nomad\\\\consul\\\\data\\\\",
+  "data_dir": "c:\\\\Users\\\\hashistack\\\\consul\\\\data\\\\",
   "node_name": "client1",
   "bind_addr": "$nomad_client_1_private_ip",
   "client_addr": "0.0.0.0",
@@ -160,13 +166,13 @@ cat <<-EOF > /root/nomad/consul-client1.json
 EOF
 
 # SCP Consul Config File to Nomad client
-sshpass -e scp /root/nomad/consul-client1.json nomad@$nomad_client_1_ip:c:\\Users\\nomad\\consul\\consul-client1.json
+sshpass -e scp /root/nomad/consul-client1.json hashistack@$nomad_client_1_ip:c:\\Users\\hashistack\\consul\\consul-client1.json
 
 # Make Consul data directory
-sshpass -e ssh nomad@$nomad_client_1_ip 'mkdir c:\Users\nomad\consul\data'
+sshpass -e ssh hashistack@$nomad_client_1_ip 'mkdir c:\Users\hashistack\consul\data'
 
 # Start Consul on Client
-sshpass -e ssh nomad@$nomad_client_1_ip 'sc start Consul'
+sshpass -e ssh hashistack@$nomad_client_1_ip 'sc start Consul'
 
 # Sleep
 sleep 15
@@ -174,7 +180,7 @@ sleep 15
 # Write Nomad Client Config
 cat <<-EOF > /root/nomad/nomad-client1.hcl
 # Setup data dir
-data_dir = "c:\\\\Users\\\\nomad\\\\nomad\\\\data\\\\"
+data_dir = "c:\\\\Users\\\\hashistack\\\\nomad\\\\data\\\\"
 
 # Give the agent a unique name.
 name = "client1"
@@ -189,25 +195,40 @@ consul {
   address = "nomad-client-1:8500"
 }
 
-log_file = "c:\\\\Users\\\\nomad\\\\nomad\\\\nomad.log"
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "docker" {
+  config {
+    pull_activity_timeout = "15m"
+  }
+}
+
+log_file = "c:\\\\Users\\\\hashistack\\\\nomad\\\\nomad.log"
 EOF
 
 # SCP Nomad Config File to Client
-sshpass -e scp /root/nomad/nomad-client1.hcl nomad@$nomad_client_1_ip:c:\\Users\\nomad\\nomad\\nomad-client1.hcl
+sshpass -e scp /root/nomad/nomad-client1.hcl hashistack@$nomad_client_1_ip:c:\\Users\\hashistack\\nomad\\nomad-client1.hcl
 
 # Make Nomad data directory
-sshpass -e ssh nomad@$nomad_client_1_ip 'mkdir c:\Users\nomad\nomad\data'
+sshpass -e ssh hashistack@$nomad_client_1_ip 'mkdir c:\Users\hashistack\nomad\data'
 
 # Start Nomad on Client
-sshpass -e ssh nomad@$nomad_client_1_ip 'sc start Nomad'
+sshpass -e ssh hashistack@$nomad_client_1_ip 'sc start Nomad'
+
+# Start Docker in case it was not started
+# sshpass -e ssh hashistack@$nomad_client_1_ip 'sc start Docker'
 
 ### Client 2
 # Write Consul Client Config
 cat <<-EOF > /root/nomad/consul-client2.json
 {
-  "log_file": "c:\\\\Users\\\\nomad\\\\consul\\\\consul.log",
+  "log_file": "c:\\\\Users\\\\hashistack\\\\consul\\\\consul.log",
   "log_level": "INFO",
-  "data_dir": "c:\\\\Users\\\\nomad\\\\consul\\\\data\\\\",
+  "data_dir": "c:\\\\Users\\\\hashistack\\\\consul\\\\data\\\\",
   "node_name": "client2",
   "bind_addr": "$nomad_client_2_private_ip",
   "client_addr": "0.0.0.0",
@@ -218,13 +239,13 @@ cat <<-EOF > /root/nomad/consul-client2.json
 EOF
 
 # SCP Consul Config File to Nomad client
-sshpass -e scp /root/nomad/consul-client2.json nomad@$nomad_client_2_ip:c:\\Users\\nomad\\consul\\consul-client2.json
+sshpass -e scp /root/nomad/consul-client2.json hashistack@$nomad_client_2_ip:c:\\Users\\hashistack\\consul\\consul-client2.json
 
 # Make Consul data directory
-sshpass -e ssh nomad@$nomad_client_2_ip 'mkdir c:\Users\nomad\consul\data'
+sshpass -e ssh hashistack@$nomad_client_2_ip 'mkdir c:\Users\hashistack\consul\data'
 
 # Start Consul on Client
-sshpass -e ssh nomad@$nomad_client_2_ip 'sc start Consul'
+sshpass -e ssh hashistack@$nomad_client_2_ip 'sc start Consul'
 
 # Sleep
 sleep 15
@@ -232,7 +253,7 @@ sleep 15
 # Write Nomad Client Config
 cat <<-EOF > /root/nomad/nomad-client2.hcl
 # Setup data dir
-data_dir = "c:\\\\Users\\\\nomad\\\\nomad\\\\data\\\\"
+data_dir = "c:\\\\Users\\\\hashistack\\\\nomad\\\\data\\\\"
 
 # Give the agent a unique name.
 name = "client2"
@@ -247,25 +268,40 @@ consul {
   address = "nomad-client-2:8500"
 }
 
-log_file = "c:\\\\Users\\\\nomad\\\\nomad\\\\nomad.log"
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "docker" {
+  config {
+    pull_activity_timeout = "15m"
+  }
+}
+
+log_file = "c:\\\\Users\\\\hashistack\\\\nomad\\\\nomad.log"
 EOF
 
 # SCP Nomad Config File to Client
-sshpass -e scp /root/nomad/nomad-client2.hcl nomad@$nomad_client_2_ip:c:\\Users\\nomad\\nomad\\nomad-client2.hcl
+sshpass -e scp /root/nomad/nomad-client2.hcl hashistack@$nomad_client_2_ip:c:\\Users\\hashistack\\nomad\\nomad-client2.hcl
 
 # Make Nomad data directory
-sshpass -e ssh nomad@$nomad_client_2_ip 'mkdir c:\Users\nomad\nomad\data'
+sshpass -e ssh hashistack@$nomad_client_2_ip 'mkdir c:\Users\hashistack\nomad\data'
 
 # Start Nomad on Client
-sshpass -e ssh nomad@$nomad_client_2_ip 'sc start Nomad'
+sshpass -e ssh hashistack@$nomad_client_2_ip 'sc start Nomad'
+
+# Start Docker in case it was not started
+# sshpass -e ssh hashistack@$nomad_client_2_ip 'sc start Docker'
 
 ### Client 3
 # Write Consul Client Config
 cat <<-EOF > /root/nomad/consul-client3.json
 {
-  "log_file": "c:\\\\Users\\\\nomad\\\\consul\\\\consul.log",
+  "log_file": "c:\\\\Users\\\\hashistack\\\\consul\\\\consul.log",
   "log_level": "INFO",
-  "data_dir": "c:\\\\Users\\\\nomad\\\\consul\\\\data\\\\",
+  "data_dir": "c:\\\\Users\\\\hashistack\\\\consul\\\\data\\\\",
   "node_name": "client3",
   "bind_addr": "$nomad_client_3_private_ip",
   "client_addr": "0.0.0.0",
@@ -276,13 +312,13 @@ cat <<-EOF > /root/nomad/consul-client3.json
 EOF
 
 # SCP Consul Config File to Nomad client
-sshpass -e scp /root/nomad/consul-client3.json nomad@$nomad_client_3_ip:c:\\Users\\nomad\\consul\\consul-client3.json
+sshpass -e scp /root/nomad/consul-client3.json hashistack@$nomad_client_3_ip:c:\\Users\\hashistack\\consul\\consul-client3.json
 
 # Make Consul data directory
-sshpass -e ssh nomad@$nomad_client_3_ip 'mkdir c:\Users\nomad\consul\data'
+sshpass -e ssh hashistack@$nomad_client_3_ip 'mkdir c:\Users\hashistack\consul\data'
 
 # Start Consul on Client
-sshpass -e ssh nomad@$nomad_client_3_ip 'sc start Consul'
+sshpass -e ssh hashistack@$nomad_client_3_ip 'sc start Consul'
 
 # Sleep
 sleep 15
@@ -290,7 +326,7 @@ sleep 15
 # Write Nomad Client Config
 cat <<-EOF > /root/nomad/nomad-client3.hcl
 # Setup data dir
-data_dir = "c:\\\\Users\\\\nomad\\\\nomad\\\\data\\\\"
+data_dir = "c:\\\\Users\\\\hashistack\\\\nomad\\\\data\\\\"
 
 # Give the agent a unique name.
 name = "client3"
@@ -305,17 +341,32 @@ consul {
   address = "nomad-client-3:8500"
 }
 
-log_file = "c:\\\\Users\\\\nomad\\\\nomad\\\\nomad.log"
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+
+plugin "docker" {
+  config {
+    pull_activity_timeout = "15m"
+  }
+}
+
+log_file = "c:\\\\Users\\\\hashistack\\\\nomad\\\\nomad.log"
 EOF
 
 # SCP Nomad Config File to Client
-sshpass -e scp /root/nomad/nomad-client3.hcl nomad@$nomad_client_3_ip:c:\\Users\\nomad\\nomad\\nomad-client3.hcl
+sshpass -e scp /root/nomad/nomad-client3.hcl hashistack@$nomad_client_3_ip:c:\\Users\\hashistack\\nomad\\nomad-client3.hcl
 
 # Make Nomad data directory
-sshpass -e ssh nomad@$nomad_client_3_ip 'mkdir c:\Users\nomad\nomad\data'
+sshpass -e ssh hashistack@$nomad_client_3_ip 'mkdir c:\Users\hashistack\nomad\data'
 
 # Start Nomad on Client
-sshpass -e ssh nomad@$nomad_client_3_ip 'sc start Nomad'
+sshpass -e ssh hashistack@$nomad_client_3_ip 'sc start Nomad'
+
+# Start Docker in case it was not started
+# sshpass -e ssh hashistack@$nomad_client_3_ip 'sc start Docker'
 
 # Sleep
 sleep 45

--- a/instruqt-tracks/nomad-on-windows/verify-nomad-cluster-health/solve-cloud-client
+++ b/instruqt-tracks/nomad-on-windows/verify-nomad-cluster-health/solve-cloud-client
@@ -8,12 +8,12 @@ set -o history
 sleep 30
 
 # Check Consul members
-sshpass -e ssh nomad@$nomad_server_ip 'consul members'
+sshpass -e ssh hashistack@$nomad_server_ip 'consul members'
 
 # Check Nomad server
-sshpass -e ssh nomad@$nomad_server_ip 'nomad server members'
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad server members'
 
 # Check Nomad clients
-sshpass -e ssh nomad@$nomad_server_ip 'nomad node status'
+sshpass -e ssh hashistack@$nomad_server_ip 'nomad node status'
 
 exit 0


### PR DESCRIPTION
I expanded the Windows on Nomad track quite a bit.  That had been more of a template track that other SEs could use to launch Nomad on windows in Instruqt.  But in order to better enable teams that might want to use it, I decided to add a second challenge and run 3  jobs that use 3 different drivers on Windows: Docker, Java and Raw Exec.

The Docker driver runs an IIS web server.
The Java driver runs Jenkins.
The Raw Exec driver runs a parameterized batch job that runs a DotNet app (courtesy of Guy Barrows) that determines whether numbers are prime or not.

Additionally, I updated the Consul Connect track to use the latest hashistack image.