### PR TITLE
fix challenge notes for Multi-Region Nomad Deployments challenge

### DIFF
--- a/instruqt-tracks/nomad-multi-region-federation/track.yml
+++ b/instruqt-tracks/nomad-multi-region-federation/track.yml
@@ -109,7 +109,7 @@ challenges:
   assignment: |-
     In this challenge you will deploy a multi-region job. Please read the notes screens that were displayed at the beginning of this challenge for an explanation of multi-region concepts.
 
-    Inspect the "/root/nomad/multi-redis.nomad" job file in the file editor on the "Config Files" tab.
+    Inspect the "/root/nomad/jobs/multi-redis.nomad" job file in the file editor on the "Config Files" tab.
 
     The job will be deployed to both regions. The `max_parallel` field of the `strategy` block of the `multiregion` block restricts Nomad to deploy to the regions one at a time since it is set to `1`. If either of the region deployments fail, both regions will be marked as `failed` since `on_failure` is set to `fail_all`.
 


### PR DESCRIPTION
correction to the notes in the Multi-Region Nomad Deployments challenge to direct the user to the proper directory for finding the job file to inspect