### PR TITLE
fixes for issues noticed in 9/15 workshop

### DIFF
--- a/docs/slides/multi-cloud/advanced-nomad/nomad-autoscaler.md
+++ b/docs/slides/multi-cloud/advanced-nomad/nomad-autoscaler.md
@@ -96,7 +96,7 @@ class: compact, smaller
   * The `cooldown` specifies a period during which no scaling actions should be taken immediately after a scaling action is taken. This avoids flapping.
   * The `target` specifies the autoscaling target. In a policy specified by the `scaling` stanza of a task group, this would generally not be specified since it defaults to the Nomad Task Group Target.
   * The `check` specifies a check to be executed to determine if a scaling action is required.
-      * The `check` specifies the APM plugin (`source`) and the Strategy plugin (`source`) to use and the `query` to run against the first.  
+      * The `check` specifies the APM plugin (`source`) and the Strategy plugin (`strategy`) to use and the `query` to run against the first.  
 
 ???
 * Autoscaling policy details

--- a/docs/slides/multi-cloud/advanced-nomad/nomad-enterprise-platform.md
+++ b/docs/slides/multi-cloud/advanced-nomad/nomad-enterprise-platform.md
@@ -26,7 +26,7 @@ layout: true
 name: Nomad Enterprise Features - Autopilot
 # Nomad Enterprise - Autopilot
 
-* [Autopilot](https://learn.hashicorp.com/nomad/operating-nomad/autopilot) is a function that enables multiple features:
+* [Autopilot](https://learn.hashicorp.com/tutorials/nomad/autopilot) is a function that enables multiple features:
     * [Automated Upgrades](https://nomadproject.io/docs/enterprise/#automated-upgrades)
     * [Enhanced Read Scalability](https://nomadproject.io/docs/enterprise/#enhanced-read-scalability)
     * [Redundancy Zones](https://nomadproject.io/docs/enterprise/#redundancy-zones)
@@ -41,7 +41,7 @@ name: Automated Upgrade Overview
 
 * Add new servers to a cluster with updated versions.
 * Autopilot won't promote new servers until a quorum is achieved.
-* Once a quorum is achieved, Autopilot pomotes new servers and demotes old ones.
+* Once a quorum is achieved, Autopilot promotes new servers and demotes old ones.
 * Autopilot can remove old servers from the cluster automatically.
 * Your upgrade is complete!
 

--- a/docs/slides/multi-cloud/advanced-nomad/nomad-governance.md
+++ b/docs/slides/multi-cloud/advanced-nomad/nomad-governance.md
@@ -35,8 +35,8 @@ name: chapter-governance-topics
 name: nomad-enterprise-audit-logging
 # Nomad Enterprise Audit Logging
 * Nomad Enterprise's [Audit Logging](https://nomadproject.io/docs/enterprise/#audit-logging) provides Nomad administrators a complete set of records for all user-issued actions in Nomad.
-* Nomad Enteprise customers can proactively identify access anomalies, ensure enforcement of their security policies, and diagnose cluster behavior by viewing preceding user operations.
-* Each audit event is captured with relevant request and response information in a JSON format that is easily digestibile and familiar to operators
+* Nomad Enterprise customers can proactively identify access anomalies, ensure enforcement of their security policies, and diagnose cluster behavior by viewing preceding user operations.
+* Each audit event is captured with relevant request and response information in a JSON format that is easily digestibile and familiar to operators.
 
 ???
 * Let's start with Nomad Enterprise's audit logging that was added in Nomad 0.11.0.
@@ -44,7 +44,7 @@ name: nomad-enterprise-audit-logging
 ---
 name: nomad-namespaces
 # Nomad Enterprise Namespaces
-* [Namespaces](https://learn.hashicorp.com/nomad/governance-and-policy/namespaces) allow multiple teams to safely share a Nomad cluster.
+* [Namespaces](https://learn.hashicorp.com/tutorials/nomad/namespaces) allow multiple teams to safely share a Nomad cluster.
 * The jobs and tasks of one namespace are isolated from those of others.
 * The namespace of a job is specified by the job's `namespace` stanza.
   * Jobs are run in the `default` namespace if none is specified.
@@ -83,7 +83,7 @@ class: compact
 ---
 name: nomad-resource-quotas
 # Nomad Enterprise Resource Quotas
-* [Resource Quotas](https://learn.hashicorp.com/nomad/governance-and-policy/quotas) allow Nomad operators to restrict the aggregate resource consumption of namespaces.
+* [Resource Quotas](https://learn.hashicorp.com/tutorials/nomad/quotas) allow Nomad operators to restrict the aggregate resource consumption of namespaces.
 * The most common resources restricted are CPU and Memory.
 * But it is also possible to restrict network usage
 
@@ -131,8 +131,8 @@ limit {
 ---
 name: nomad-sentinel-policies
 # Nomad Enterprise Sentinel Policies
-* [Sentinel Policies](https://learn.hashicorp.com/nomad/governance-and-policy/sentinel) in Nomad restrict the characteristics of jobs submitted to Nomad.
-* Sentinel policies extend and require the Nomad [ACL system](https://learn.hashicorp.com/nomad/acls/fundamentals).
+* [Sentinel Policies](https://learn.hashicorp.com/tutorials/nomad/sentinel) in Nomad restrict the characteristics of jobs submitted to Nomad.
+* Sentinel policies extend and require the Nomad [ACL system](https://learn.hashicorp.com/tutorials/nomad/access-control).
 * Nomad Sentinel policies can do things like:
   * Restrict which drivers are allowed.
   * Restrict which Docker images can be used.

--- a/docs/slides/multi-cloud/advanced-nomad/nomad-job-update-strategies.md
+++ b/docs/slides/multi-cloud/advanced-nomad/nomad-job-update-strategies.md
@@ -46,7 +46,7 @@ name: update-strategy-applicability
 ---
 name: rolling-updates
 # Rolling Updates
-* [Rolling Updates](https://learn.hashicorp.com/nomad/update-strategies/rolling-upgrades) are the default update strategy within Nomad.
+* [Rolling Updates](https://learn.hashicorp.com/tutorials/nomad/job-rolling-update) are the default update strategy within Nomad.
 * In a rolling update, new allocations of a task group gradually replace existing allocations in batches.
 * The `max_parallel` attribute of the `update` stanza specifies how many allocations should be replaced in parallel.
 * However, Nomad only advances from one batch of parallel allocations to the next batch if all tasks deployed in the previous batch are healthy.
@@ -88,7 +88,7 @@ group "api" {
 name: blue-green-deployments
 class: compact
 # Blue/Green Deployments
-* In a [Blue/Green Deployment](https://learn.hashicorp.com/nomad/update-strategies/blue-green-and-canary-deployments#bluegreen-deployments), two different versions of an application are run side-by-side so that they can be compared.
+* In a [Blue/Green Deployment](https://learn.hashicorp.com/tutorials/nomad/job-blue-green-and-canary-deployments#bluegreen-deployments), two different versions of an application are run side-by-side so that they can be compared.
 * In the Nomad context, a number of new allocations equal to the `count` of the task group are deployed while the same number of allocations that were previously deployed continue to run.
 * Blue/Green deployments in Nomad are configured by setting the `canary` attribute of the `update` stanza equal to the `count` of the task group.
 * The deployment has to be manually [promoted](https://nomadproject.io/docs/commands/deployment/promote/) before the old allocations are terminated.
@@ -126,7 +126,7 @@ group "api" {
 ---
 name: canary-deployments
 # Canary Deployments
-* In a [Canary Deployment](https://learn.hashicorp.com/nomad/update-strategies/blue-green-and-canary-deployments#deploy-with-canaries), a small number of new instances of an application are deployed alongside the existing one.
+* In a [Canary Deployment](https://learn.hashicorp.com/tutorials/nomad/job-blue-green-and-canary-deployments#deploy-with-canaries), a small number of new instances of an application are deployed alongside the existing one.
 * Coal miners used to take canaries into mines since the birds got sick from dangerous gas leaks before the miners did.
 * In the Nomad context, a number of new allocations equal to the `canary` attribute of the `update` stanza are deployed.
 * Note that a Blue/Green deployment in Nomad is a special case of a Canary deployment.

--- a/docs/slides/multi-cloud/advanced-nomad/nomad-security.md
+++ b/docs/slides/multi-cloud/advanced-nomad/nomad-security.md
@@ -93,7 +93,6 @@ Nomad's use of mTLS provides the following benefits:
 * Prevents observing or tampering with Nomad communication
 * Prevents client/server role or region misconfigurations
 * Prevents other services from masquerading as Nomad agents
-* Prevents misconfiguration of Nomad regions
 ]
 
 ???

--- a/docs/slides/multi-cloud/advanced-nomad/nomad-stateful-workloads.md
+++ b/docs/slides/multi-cloud/advanced-nomad/nomad-stateful-workloads.md
@@ -176,7 +176,7 @@ name: lab-host-volumes
   * [Nomad Host Volumes](https://play.instruqt.com/hashicorp/invite/1cxyk78sgqja)
   * [Nomad Integration with Portworx](https://play.instruqt.com/hashicorp/invite/nrfcdqrghxiq)
   * [Nomad CSI Plugins (GCP)](https://play.instruqt.com/hashicorp/invite/x2ongtdbbbwe)
-* To explore using Nomad with the [AWS EBS CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html), please see the [Stateful Workloads with Container Storage Interface](https://learn.hashicorp.com/nomad/stateful-workloads/csi-volumes) learn track.
+* To explore using Nomad with the [AWS EBS CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html), please see the [Stateful Workloads with Container Storage Interface](https://learn.hashicorp.com/tutorials/nomad/stateful-workloads-csi-volumes) learn track.
 * We hope to have an Instruqt track that implements that AWS learn track in the near future.
 
 ???

--- a/instruqt-tracks/nomad-and-csi-plugins-gcp/track.yml
+++ b/instruqt-tracks/nomad-and-csi-plugins-gcp/track.yml
@@ -14,7 +14,7 @@ description: |-
 
   This track will guide you through using a Nomad CSI Plugin to persist data for a MySQL database using a Google Persistent Disk and the [GCP Persistent Disk CSI Driver](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver).
 
-  It is based on the [Stateful Workloads with Container Storage Interface](https://learn.hashicorp.com/nomad/stateful-workloads/csi-volumes) guide, but runs in GCP instead of AWS.
+  It is based on the [Stateful Workloads with Container Storage Interface](https://learn.hashicorp.com/tutorials/nomad/stateful-workloads-csi-volumes) guide, but runs in GCP instead of AWS.
 
   Before running this track, we suggest you run the [Nomad Basics](https://play.instruqt.com/hashicorp/tracks/nomad-basics) track.
 
@@ -487,4 +487,4 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 1200
-checksum: "18235609306602126285"
+checksum: "16202575105132404972"

--- a/instruqt-tracks/nomad-and-portworx/install-portworx/setup-cloud-client
+++ b/instruqt-tracks/nomad-and-portworx/install-portworx/setup-cloud-client
@@ -32,7 +32,6 @@ job "portworx" {
       healthy_deadline = "5m"
       auto_revert      = true
       canary           = 0
-      stagger          = "30s"
     }
 
     task "px-node" {

--- a/instruqt-tracks/nomad-and-portworx/track.yml
+++ b/instruqt-tracks/nomad-and-portworx/track.yml
@@ -12,7 +12,7 @@ description: |-
     * [Docker Volume Drivers](https://docs.docker.com/engine/extend/plugins_volume/#create-a-volumedriver) such as Portworx that are externally managed and can only be used with the Docker task driver
     * [CSI Plugins](https://github.com/container-storage-interface/spec/blob/master/spec.md) that are also externally managed but can be used with many Nomad task drivers including Docker, Exec, and Java
 
-  This track will guide you through using a [Docker Volume Driver](https://nomadproject.io/docs/drivers/docker/#inlinecode-volumes-16) and [Portworx](https://docs.portworx.com/install-with-other/nomad) to persist data for an HA MySQL database deployed by Nomad. It is based on the [Stateful Workloads with Portworx](https://learn.hashicorp.com/nomad/stateful-workloads/portworx) guide.
+  This track will guide you through using a [Docker Volume Driver](https://nomadproject.io/docs/drivers/docker/#inlinecode-volumes-16) and [Portworx](https://docs.portworx.com/install-with-other/nomad) to persist data for an HA MySQL database deployed by Nomad. It is based on the [Stateful Workloads with Portworx](https://learn.hashicorp.com/tutorials/nomad/stateful-workloads-portworx) guide.
 
   Before running this track, we suggest you run the [Nomad Basics](https://play.instruqt.com/hashicorp/tracks/nomad-basics) track.
 
@@ -441,4 +441,4 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 600
-checksum: "12854960168407950057"
+checksum: "15609899725862352054"

--- a/instruqt-tracks/nomad-basics/track.yml
+++ b/instruqt-tracks/nomad-basics/track.yml
@@ -101,7 +101,7 @@ challenges:
     contents: |-
       In this challenge, you will run your first Nomad agent in development mode and explore a few more Nomad CLI commands.
 
-      See https://learn.hashicorp.com/nomad/getting-started/running#starting-the-agent for more on Nomad's development mode.
+      See https://learn.hashicorp.com/tutorials/nomad/get-started-run#starting-the-agent for more on Nomad's development mode.
   tabs:
   - title: Nomad Dev Server
     type: terminal
@@ -184,7 +184,7 @@ challenges:
     contents: |-
       In this challenge, you'll run your first Nomad job using a Nomad job specification file that has been provided.
 
-      See https://learn.hashicorp.com/nomad/getting-started/jobs for more on running Nomad jobs.
+      See https://learn.hashicorp.com/tutorials/nomad/get-started-jobs for more on running Nomad jobs.
   tabs:
   - title: Nomad CLI
     type: terminal
@@ -254,4 +254,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "3199321748375481850"
+checksum: "14512621176357453077"

--- a/instruqt-tracks/nomad-consul-connect/track.yml
+++ b/instruqt-tracks/nomad-consul-connect/track.yml
@@ -129,7 +129,7 @@ challenges:
 
       This challenge is based on the  Consul Connect](https://www.nomadproject.io/docs/integrations/consul-connect/) in the Nomad documentation.
 
-      There is also a [version](https://learn.hashicorp.com/nomad/consul-integration/nomad-connect-acl) of this guide that can be used with a Consul cluster that has Consul ACLs enabled.
+      There is also a [version](https://learn.hashicorp.com/tutorials/nomad/consul-service-mesh) of this guide that can be used with a Consul cluster that has Consul ACLs enabled.
   tabs:
   - title: Config Files
     type: code
@@ -156,4 +156,4 @@ challenges:
     port: 9002
   difficulty: basic
   timelimit: 2700
-checksum: "13920906307534493849"
+checksum: "13132293051674240295"

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-1/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-1/setup-nomad-server-1
@@ -36,7 +36,6 @@ job "catalogue" {
   }
 
   update {
-    stagger = "10s"
     max_parallel = 1
   }
 
@@ -142,7 +141,6 @@ job "webserver-test" {
   }
 
   update {
-    stagger = "10s"
     max_parallel = 1
   }
 
@@ -201,7 +199,6 @@ job "website" {
   }
 
   update {
-    stagger = "10s"
     max_parallel = 1
   }
 
@@ -298,7 +295,6 @@ job "website" {
   }
 
   update {
-    stagger = "10s"
     max_parallel = 1
   }
 

--- a/instruqt-tracks/nomad-governance/track.yml
+++ b/instruqt-tracks/nomad-governance/track.yml
@@ -5,9 +5,9 @@ title: Nomad Enterprise Governance
 teaser: |
   Learn how to use Nomad Enterprise's governance capabilities including namespaces, resource quotas, and Sentinel policies.
 description: |-
-  This track will show you how to use Nomad Enterprise's governance capabilities including [Audit Logging](https://www.nomadproject.io/docs/enterprise#audit-logging), [Namespaces](https://learn.hashicorp.com/nomad/governance-and-policy/namespaces), [Resource Quotas](https://learn.hashicorp.com/nomad/governance-and-policy/quotas), [Sentinel Policies](https://learn.hashicorp.com/nomad/governance-and-policy/sentinel), and [Cross-Namespace Queries](https://www.nomadproject.io/docs/enterprise#cross-namespace-queries).
+  This track will show you how to use Nomad Enterprise's governance capabilities including [Audit Logging](https://www.nomadproject.io/docs/enterprise#audit-logging), [Namespaces](https://learn.hashicorp.com/tutorials/nomad/namespaces), [Resource Quotas](https://learn.hashicorp.com/tutorials/nomad/quotas), [Sentinel Policies](https://learn.hashicorp.com/tutorials/nomad/sentinel), and [Cross-Namespace Queries](https://www.nomadproject.io/docs/enterprise#cross-namespace-queries).
 
-  You will also configure and use [Nomad ACLs](https://learn.hashicorp.com/nomad/acls/fundamentals) which are applicable to namespaces and resource quotas and required by Nomad Sentinel policies.
+  You will also configure and use [Nomad ACLs](https://learn.hashicorp.com/tutorials/nomad/access-control) which are applicable to namespaces and resource quotas and required by Nomad Sentinel policies.
 
   Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics) and [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster) tracks.
 icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
@@ -62,7 +62,7 @@ challenges:
     contents: |-
       In this challenge, you will verify the health of the Nomad Enterprise cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-      In later challenges, you will enable Nomad Enterprise's [Audit Logging](https://www.nomadproject.io/docs/enterprise#audit-logging) and define Nomad [Namespaces](https://learn.hashicorp.com/nomad/governance-and-policy/namespaces), [Resource Quotas](https://learn.hashicorp.com/nomad/governance-and-policy/quotas), [Nomad ACLs](https://learn.hashicorp.com/nomad/acls/fundamentals), and [Sentinel Policies](https://learn.hashicorp.com/nomad/governance-and-policy/sentinel).
+      In later challenges, you will enable Nomad Enterprise's [Audit Logging](https://www.nomadproject.io/docs/enterprise#audit-logging) and define Nomad [Namespaces](https://learn.hashicorp.com/tutorials/nomad/namespaces), [Resource Quotas](https://learn.hashicorp.com/tutorials/nomad/quotas), [Nomad ACLs](https://learn.hashicorp.com/tutorials/nomad/access-control), and [Sentinel Policies](https://learn.hashicorp.com/tutorials/nomad/sentinel).
 
       You will then run jobs and learn how Sentinel policies and resource quotas restrict them. You'll also run a [Cross-Namespace Query](https://www.nomadproject.io/docs/enterprise#cross-namespace-queries)
   tabs:
@@ -372,7 +372,7 @@ challenges:
     Nomad ACLs are also required to use Nomad Sentinel policies since only users with the suitable ACL policies can apply Sentinel policies.
 
     ## Enable the ACL System
-    Start by reviewing the "nomad-server1.hcl", "nomad-client1.hcl", "nomad-client1.hcl", and "nomad-client1.hcl" files on the "Config Files" tab. Notice that the following stanza has been added to the bottom of each file:<br>
+    Start by reviewing the "nomad-server1.hcl", "nomad-client1.hcl", "nomad-client2.hcl", and "nomad-client3.hcl" files on the "Config Files" tab. Notice that the following stanza has been added to the bottom of each file:<br>
     `
     acl {
       enabled = true
@@ -862,7 +862,11 @@ challenges:
 
     You'll then need to select the "Jobs" menu and click the Instruqt refresh icon to make the Nomad UI show the namespace selector which will let you select the "dev" namespace. If you click on the "website" job in the "dev" namespace, you will see 4 Desired, Placed, and Healthy allocations.
 
-    Run `nomad quota status dev` on the "Server" tab again to see how much of the "dev" resource quota is being used. You should now see this:<br>
+    Check the status of the dev resource quota on the "Server" tab again to see how much of the "dev" resource quota is being used:
+    ```
+    nomad quota status dev
+    ```
+    You should now see this:<br>
     `
     Name        = dev
     Description = dev quota
@@ -975,4 +979,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "12824447933311762252"
+checksum: "9490140127686699643"

--- a/instruqt-tracks/nomad-host-volumes/track.yml
+++ b/instruqt-tracks/nomad-host-volumes/track.yml
@@ -12,7 +12,7 @@ description: |-
     * [Docker Volume Drivers](https://docs.docker.com/engine/extend/plugins_volume/#create-a-volumedriver) such as Portworx that are externally managed and can only be used with the Docker task driver
     * [CSI Plugins](https://github.com/container-storage-interface/spec/blob/master/spec.md) that are also externally managed but can be used with many Nomad task drivers including Docker, Exec, and Java
 
-  This track will guide you through using Nomad Host Volumes to persist data for a MySQL database. It is based on the [Stateful Workloads with Nomad Host Volumes](https://learn.hashicorp.com/nomad/stateful-workloads/host-volumes) guide.
+  This track will guide you through using Nomad Host Volumes to persist data for a MySQL database. It is based on the [Stateful Workloads with Nomad Host Volumes](https://learn.hashicorp.com/tutorials/nomad/stateful-workloads-host-volumes) guide.
 
   Before running this track, we suggest you run the [Nomad Basics](https://play.instruqt.com/hashicorp/tracks/nomad-basics) track.
 
@@ -411,4 +411,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 600
-checksum: "11615840011778944406"
+checksum: "8499451688467099140"

--- a/instruqt-tracks/nomad-job-placement/track.yml
+++ b/instruqt-tracks/nomad-job-placement/track.yml
@@ -144,7 +144,7 @@ challenges:
     constraints = ["tag==service"]
     `<br>
 
-    If you look back at the "webapp.nomad" job specification, on line 30 you will see that the same service tag was specified in the tags section of the registration of the web app with Consul.
+    If you look back at the "webapp.nomad" job specification, on line 33 you will see that the same service tag was specified in the tags section of the registration of the web app with Consul.
     <br>
     `
     tags = [
@@ -183,8 +183,6 @@ challenges:
   - type: text
     contents: |-
       In this challenge, you will run Nomad jobs that deploy a web application and [Traefik](https://containo.us/traefik/), which will serve as a load balancer in front of multiple instances of the web app.
-
-      ![alt text](https://containo.us/assets/img/traefik-logo.svg)
 
       In later challenges, you will learn about Nomad Spread, Constraints, and Affinities.
   tabs:
@@ -499,4 +497,4 @@ challenges:
     port: 8080
   difficulty: basic
   timelimit: 600
-checksum: "18142120775381220820"
+checksum: "6077355159864770265"

--- a/instruqt-tracks/nomad-monitoring/track.yml
+++ b/instruqt-tracks/nomad-monitoring/track.yml
@@ -7,7 +7,7 @@ teaser: |
 description: |-
   The Nomad client and server agents collect runtime [telemetry](https://www.nomadproject.io/docs/telemetry/index.html). Operators can use this data to gain real-time visibility into their Nomad clusters and improve performance. Additionally, Nomad operators can set up monitoring and alerting against these metrics and export the metrics to tools like Prometheus, Grafana, Graphite, DataDog, and Circonus.
 
-  This track will guide you through implementing the [Using Prometheus to Monitor Nomad Metrics](https://learn.hashicorp.com/nomad/operating-nomad/prometheus-metrics) guide.
+  This track will guide you through implementing the [Using Prometheus to Monitor Nomad Metrics](https://learn.hashicorp.com/tutorials/nomad/prometheus-metrics) guide.
 
   Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics), [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster), and the [Nomad Multi-Server Cluster](https://instruqt.com/hashicorp/tracks/nomad-multi-server-cluster) tracks.
 icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
@@ -146,7 +146,7 @@ challenges:
 
       Additionally, Nomad operators can set up monitoring and alerting against these metrics and export the metrics to tools like Prometheus, Grafana, Graphite, DataDog, and Circonus.
 
-      This track will guide you through implementing the [Using Prometheus to Monitor Nomad Metrics](https://learn.hashicorp.com/nomad/operating-nomad/prometheus-metrics) guide.
+      This track will guide you through implementing the [Using Prometheus to Monitor Nomad Metrics](https://learn.hashicorp.com/tutorials/nomad/prometheus-metrics) guide.
   - type: text
     contents: |-
       The setup scripts for this track have configured 4 VMs running Nomad and Consul agents. One is functioning as a server while the other 3 are functioning as clients, both with regard to Nomad and to Consul.
@@ -393,4 +393,4 @@ challenges:
     port: 9999
   difficulty: basic
   timelimit: 1200
-checksum: "17249993678455077771"
+checksum: "4598853773109752482"

--- a/instruqt-tracks/nomad-multi-region-federation/multi-region-deployments/setup-nomad-server-1-east
+++ b/instruqt-tracks/nomad-multi-region-federation/multi-region-deployments/setup-nomad-server-1-east
@@ -33,7 +33,6 @@ job "example" {
     auto_revert       = true
     auto_promote      = true
     canary            = 1
-    stagger           = "30s"
   }
 
 

--- a/instruqt-tracks/nomad-multi-region-federation/multi-region-deployments/setup-nomad-server-1-west
+++ b/instruqt-tracks/nomad-multi-region-federation/multi-region-deployments/setup-nomad-server-1-west
@@ -33,7 +33,6 @@ job "example" {
     auto_revert       = true
     auto_promote      = true
     canary            = 1
-    stagger           = "30s"
   }
 
 

--- a/instruqt-tracks/nomad-multi-region-federation/simulate-failed-deployment/setup-nomad-server-1-east
+++ b/instruqt-tracks/nomad-multi-region-federation/simulate-failed-deployment/setup-nomad-server-1-east
@@ -32,7 +32,6 @@ job "example" {
     auto_revert       = true
     auto_promote      = true
     canary            = 1
-    stagger           = "30s"
   }
 
 

--- a/instruqt-tracks/nomad-multi-region-federation/simulate-failed-deployment/setup-nomad-server-1-west
+++ b/instruqt-tracks/nomad-multi-region-federation/simulate-failed-deployment/setup-nomad-server-1-west
@@ -31,7 +31,6 @@ job "example" {
     auto_revert       = true
     auto_promote      = true
     canary            = 1
-    stagger           = "30s"
   }
 
 

--- a/instruqt-tracks/nomad-multi-region-federation/track.yml
+++ b/instruqt-tracks/nomad-multi-region-federation/track.yml
@@ -319,4 +319,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 1200
-checksum: "1513808108184749544"
+checksum: "7406339294124852606"

--- a/instruqt-tracks/nomad-update-strategies/track.yml
+++ b/instruqt-tracks/nomad-update-strategies/track.yml
@@ -7,7 +7,7 @@ teaser: |
 description: |-
   Most applications are long-lived and require updates over time. Whether you are deploying a new version of your web application or updating to a new version of a database, Nomad has built-in support for rolling, blue/green, and canary updates, which can be used with non-containerized and containerized applications or to containerize the former.
 
-  This track will guide you through implementing these update strategies based on the [Nomad Job Update Strategies](https://learn.hashicorp.com/nomad/update-strategies/) guide.
+  This track will guide you through implementing these update strategies based on the [Nomad Job Update Strategies](https://learn.hashicorp.com/tutorials/nomad/job-update-strategies) guide.
 
   You will run "mongodb", "chat-app", and "nginx" jobs and update the second using rolling, blue/green, and canary update strategies.
 
@@ -710,4 +710,4 @@ challenges:
     port: 8080
   difficulty: basic
   timelimit: 600
-checksum: "2258153190038980039"
+checksum: "13201654053878926155"


### PR DESCRIPTION
Fixes for various issues noticed during the 9/15 Advanced Nomad Workshop:

1. Update all learn.hashicorp.com links to use "tutorials"
2. Remove "stagger" from jobs since is only used for system jobs.
3. Remove link to Traefik logo which is no longer valid. (and I could not find suitable replacement)
4. Remove 5th bullet from slide 74
5. Change second source to strategy in slide 101
6. Change "pomotes" to "promotes" in slide 107
7. Change "enteprise" to "enterprise" in slide 117 and add a period.
8. Fix repeated references to client1 to be client1, client2, client3

