### PR TITLE
fix nomad-and-portworx

### DIFF
--- a/instruqt-tracks/nomad-and-csi-plugins-gcp/track.yml
+++ b/instruqt-tracks/nomad-and-csi-plugins-gcp/track.yml
@@ -45,7 +45,7 @@ challenges:
   assignment: |-
     In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 0.12.4 and Consul 1.8.3. These VMs have been created in a GCP project within this Instruqt track.
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 1.0.0 and Consul 1.9.0. These VMs have been created in a GCP project within this Instruqt track.
 
     If you want, you can inspect the Nomad and Consul configuration files on the "Config Files" tab.
 

--- a/instruqt-tracks/nomad-and-portworx/install-portworx/setup-cloud-client
+++ b/instruqt-tracks/nomad-and-portworx/install-portworx/setup-cloud-client
@@ -59,7 +59,7 @@ job "portworx" {
 
       # container config
       config {
-        image        = "portworx/oci-monitor:2.4.0"
+        image        = "portworx/oci-monitor:2.6.2"
         network_mode = "host"
         ipc_mode = "host"
         privileged = true

--- a/instruqt-tracks/nomad-and-portworx/track.yml
+++ b/instruqt-tracks/nomad-and-portworx/track.yml
@@ -41,7 +41,7 @@ challenges:
   assignment: |-
     In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 0.12.4 and Consul 1.8.3. These VMs have been created in a GCP project within this Instruqt track. The Nomad client VMs each were created with an extra empty 20GB [Google Persistent Disk](https://cloud.google.com/persistent-disk) for use by Portworx.
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 1.0.0 and Consul 1.9.0. These VMs have been created in a GCP project within this Instruqt track. The Nomad client VMs each were created with an extra empty 20GB [Google Persistent Disk](https://cloud.google.com/persistent-disk) for use by Portworx.
 
     You can visit the Google Cloud Console for the GCP project of your instance of the Instruqt track by selecting the "Cloud Links" tab, right-clicking the Project ID for the "nomad" Google cloud project, and then opening the console in a new tab or window. If you already have your own GCP account, it will be easier to use an incognito window. Either way, you will have to paste the Email and then the Password from the Cloud Links tab into the dialog screens that will be displayed. You will then have to click an "Accept" button. Finally, after the Google Cloud Console is displayed, you will have to click a checkbox and agree to the terms of service by clicking the "Agree and Continue" button.
 
@@ -441,4 +441,4 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 600
-checksum: "4333919420325185160"
+checksum: "6852385657607390552"

--- a/instruqt-tracks/nomad-and-portworx/verify-nomad-cluster-health/setup-cloud-client
+++ b/instruqt-tracks/nomad-and-portworx/verify-nomad-cluster-health/setup-cloud-client
@@ -1,16 +1,16 @@
 #!/bin/bash -l
 
 # Create Nomad Server
-gcloud compute instances create nomad-server-1 --image-project=instruqt-hashicorp --image=hashistack-0-9-1 --zone=europe-west1-b --boot-disk-size=20GB --tags=nomad-portworx --machine-type=n1-standard-2
+gcloud compute instances create nomad-server-1 --image-project=instruqt-hashicorp --image=hashistack-0-9-1 --zone=europe-west1-b --boot-disk-size=20GB --tags=nomad-portworx --machine-type=n1-standard-4
 
 # Create Nomad Client 1
-gcloud compute instances create nomad-client-1 --image-project=instruqt-hashicorp --image=hashistack-0-9-1 --zone=europe-west1-b --boot-disk-size=20GB --create-disk=name=portworx-1,size=20GB --tags=nomad-portworx --machine-type=n1-standard-2
+gcloud compute instances create nomad-client-1 --image-project=instruqt-hashicorp --image=hashistack-0-9-1 --zone=europe-west1-b --boot-disk-size=20GB --create-disk=name=portworx-1,size=20GB --tags=nomad-portworx --machine-type=n1-standard-4
 
 # Create Nomad Client 2
-gcloud compute instances create nomad-client-2 --image-project=instruqt-hashicorp --image=hashistack-0-9-1 --zone=europe-west1-b --boot-disk-size=20GB --create-disk=name=portworx-2,size=20GB --tags=nomad-portworx --machine-type=n1-standard-2
+gcloud compute instances create nomad-client-2 --image-project=instruqt-hashicorp --image=hashistack-0-9-1 --zone=europe-west1-b --boot-disk-size=20GB --create-disk=name=portworx-2,size=20GB --tags=nomad-portworx --machine-type=n1-standard-4
 
 # Create Nomad Client 3
-gcloud compute instances create nomad-client-3 --image-project=instruqt-hashicorp --image=hashistack-0-9-1 --zone=europe-west1-b --boot-disk-size=20GB --create-disk=name=portworx-3,size=20GB --tags=nomad-portworx --machine-type=n1-standard-2
+gcloud compute instances create nomad-client-3 --image-project=instruqt-hashicorp --image=hashistack-0-9-1 --zone=europe-west1-b --boot-disk-size=20GB --create-disk=name=portworx-3,size=20GB --tags=nomad-portworx --machine-type=n1-standard-4
 
 # Create Inbound HTTP Rule
 gcloud compute firewall-rules create nomad-allow-inbound-http --allow tcp:4646
@@ -169,7 +169,6 @@ plugin "docker" {
 
     volumes {
       enabled      = true
-      selinuxlabel = "z"
     }
   }
 }
@@ -249,7 +248,6 @@ plugin "docker" {
 
     volumes {
       enabled      = true
-      selinuxlabel = "z"
     }
   }
 }
@@ -329,7 +327,6 @@ plugin "docker" {
 
     volumes {
       enabled      = true
-      selinuxlabel = "z"
     }
   }
 }

--- a/instruqt-tracks/nomad-consul-connect/track.yml
+++ b/instruqt-tracks/nomad-consul-connect/track.yml
@@ -29,7 +29,7 @@ challenges:
   assignment: |-
     In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-    The cluster is running 1 Nomad/Consul server and 2 Nomad/Consul clients. They are using Nomad 0.12.4 and Consul 1.8.3.
+    The cluster is running 1 Nomad/Consul server and 2 Nomad/Consul clients. They are using Nomad 1.0.0 and Consul 1.9.0.
 
     First, verify that all 3 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
     ```

--- a/instruqt-tracks/nomad-governance/track.yml
+++ b/instruqt-tracks/nomad-governance/track.yml
@@ -36,7 +36,7 @@ challenges:
 
     The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients. Each of these has 3.75GB of memory and 1 virtual CPU with 2,300MHz of CPU capacity. This means that the total capacity of the 3 Nomad clients is 11.25GB of memory and 6,900MHz of CPU capacity.
 
-    The cluster is using Nomad 0.12.4 and Consul 1.8.3.
+    The cluster is using Nomad 1.0.0 and Consul 1.9.0.
 
     First, verify that all 4 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
     ```

--- a/instruqt-tracks/nomad-host-volumes/track.yml
+++ b/instruqt-tracks/nomad-host-volumes/track.yml
@@ -41,7 +41,7 @@ challenges:
   assignment: |-
     In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 0.12.4 and Consul 1.8.3.
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 1.0.0 and Consul 1.9.0.
 
     First, verify that all 4 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
     ```

--- a/instruqt-tracks/nomad-job-placement/track.yml
+++ b/instruqt-tracks/nomad-job-placement/track.yml
@@ -34,7 +34,7 @@ challenges:
   assignment: |-
     In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients. They are using Nomad 0.12.4 and Consul 1.8.3.
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients. They are using Nomad 1.0.0 and Consul 1.9.0.
 
     First, verify that all 4 Consul agents are running and connected to the cluster by running this command on the "Server" tab:
     ```

--- a/instruqt-tracks/nomad-multi-region-federation/track.yml
+++ b/instruqt-tracks/nomad-multi-region-federation/track.yml
@@ -34,7 +34,7 @@ challenges:
   teaser: |
     Nomad 0.12 introduced a breakthrough Multi-Cluster Deployment feature, which makes Nomad the first and only orchestrator on the market with complete and fully-supported federation capabilities for production.
   assignment: |-
-    The setup scripts of this track have already deployed two Nomad clusters for you in GCP. One is designated as the "west" region/cluster while the other is designated as the "east" region/cluster. They each have one server and two clients running Nomad 0.12.4 and Consul 1.8.3.
+    The setup scripts of this track have already deployed two Nomad clusters for you in GCP. One is designated as the "west" region/cluster while the other is designated as the "east" region/cluster. They each have one server and two clients running Nomad 1.0.0 and Consul 1.9.0.
 
     You'll have a total of 5 tabs in all 3 challenges of this track:
       * The "Config Files" tab will let you view the Nomad and Consul configuration files and edit a job specification file.

--- a/instruqt-tracks/nomad-on-windows/track.yml
+++ b/instruqt-tracks/nomad-on-windows/track.yml
@@ -36,7 +36,7 @@ challenges:
 
     You can see the VMs that were created for you by clicking the icon with 3 horizontal bars in the upper left corner of the console, selecting the "Compute Engine" menu, and then selecting "VM Instances".
 
-    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 0.12.3 and Consul 1.8.3. These VMs have been created in a GCP project within this Instruqt track.
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients with Nomad 1.0.0 and Consul 1.9.0. These VMs have been created in a GCP project within this Instruqt track.
 
     Additionally, OpenJDK 11 has been installed for you so that you can use Nomad's Java driver if desired.
 

--- a/instruqt-tracks/nomad-update-strategies/track.yml
+++ b/instruqt-tracks/nomad-update-strategies/track.yml
@@ -43,7 +43,7 @@ challenges:
   assignment: |-
     In this challenge, you will verify the health of the Nomad cluster that has been deployed for you by the track's setup scripts. This will include checking the health of a Consul cluster that has been set up on the same VMs.
 
-    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients running Nomad 0.12.4 and Consul 1.8.3.
+    The cluster is running 1 Nomad/Consul server and 3 Nomad/Consul clients running Nomad 1.0.0 and Consul 1.9.0.
 
     The [Consul Connect integration](https://www.nomadproject.io/docs/integrations/consul-connect/) has been enabled on the server and clients since the chatapp uses it to talk to the MongoDB database. Additionally, a Nomad [host volume](https://nomadproject.io/docs/configuration/client/#host_volume-stanza) called "mongodb_mount" has been configured on the clients under the /opt/mongodb/data directory so that MongoDB can persist its data.
 


### PR DESCRIPTION
fixed nomad-and-portworx track by using newer docker image portworx/oci-monitor:2.6.2 instead of portworx/oci-monitor:2.4.0 and by changing VMs to use machine-type=n1-standard-4 instead of machine-type=n1-standard-2 since the newer version of the image requires VMs with 4 virtual CPUs.

I also changed Nomad client configuration files to use 
```
plugin "docker" {
  config {
    allow_privileged = true

    volumes {
      enabled      = true
    }
  }
}
```