### PR TITLE
Add portworx back to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,6 +428,46 @@ jobs:
               echo "Instruqt track test failed three times."
               exit 1
             fi
+  instruqt-test-nomad-and-portworx:
+    docker:
+      - image: ubuntu:latest
+    steps:
+      - checkout
+      - run:
+          name: Run Instruqt Test
+          command: |
+            VERSION=$INSTRUQT_VERSION
+            apt -y update
+            apt -y install wget unzip
+            wget https://github.com/instruqt/cli/releases/download/${VERSION}/instruqt-linux-${VERSION}.zip -O /tmp/instruqt.zip
+            cd /tmp
+            unzip instruqt.zip
+            cp instruqt /usr/local/bin/instruqt
+            chmod +x /usr/local/bin/instruqt
+            echo "yes" | instruqt version
+            RETVAL=$?
+            if [[ $RETVAL -ne 0 ]]; then
+              echo "Instruqt is not installed correctly."
+              exit 1
+            else
+              echo "Instruqt is installed and updated to most recent version."
+            fi
+            cd /root/project/instruqt-tracks/nomad-and-portworx
+            echo "Running instruqt track push..."
+            instruqt track push --force
+            echo "Running instruqt track test..."
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 60
+            done
+            if [ $n -ge 3 ]; then
+              echo "Instruqt track test failed three times."
+              exit 1
+            fi
   instruqt-test-nomad-csi-plugins-gcp:
     docker:
       - image: docker.mirror.hashicorp.services/ubuntu:latest
@@ -656,6 +696,12 @@ workflows:
           filters:
             branches:
               only: master
+      - instruqt-test-nomad-and-portworx:
+          requires:
+            - instruqt-validate
+          filters:
+            branches:
+              only: master
       - instruqt-test-nomad-csi-plugins-gcp:
           requires:
             - instruqt-validate
@@ -718,6 +764,9 @@ workflows:
           requires:
             - instruqt-validate
       - instruqt-test-nomad-host-volumes:
+          requires:
+            - instruqt-validate
+      - instruqt-test-nomad-and-portworx:
           requires:
             - instruqt-validate
       - instruqt-test-nomad-csi-plugins-gcp:

--- a/instruqt-tracks/nomad-multi-server-cluster/manual-clustering/solve-nomad-server-3
+++ b/instruqt-tracks/nomad-multi-server-cluster/manual-clustering/solve-nomad-server-3
@@ -15,4 +15,7 @@ nomad server members
 # Check the Nomad nodes
 nomad node status
 
+# Sleep
+sleep 30
+
 exit 0

--- a/instruqt-tracks/nomad-simple-cluster/run-the-server-and-clients/solve-nomad-server
+++ b/instruqt-tracks/nomad-simple-cluster/run-the-server-and-clients/solve-nomad-server
@@ -16,4 +16,7 @@ nomad server members
 # Check the Nomad nodes
 nomad node status
 
+# Sleep
+sleep 30
+
 exit 0


### PR DESCRIPTION
Add nomad-and-portworx track back to CircleCI testing
Also add sleep to final solve challenges of nomad-simple-cluster and nomad-multi-server-clusters since the check scripts after the solve scripts are sometimes failing after having upgraded to Nomad 1.0.0