### PR TITLE
update network stanzas

### DIFF
--- a/instruqt-tracks/nomad-governance/namespaces-and-resource-quotas/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/namespaces-and-resource-quotas/setup-nomad-server-1
@@ -44,4 +44,6 @@ limit {
 }
 EOF
 
+set-workdir /root/nomad/quotas
+
 exit 0

--- a/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-client-1
@@ -9,4 +9,5 @@ acl {
 }
 EOF
 
+set-workdir /root/nomad/acls
 exit 0

--- a/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-client-2
@@ -9,4 +9,6 @@ acl {
 }
 EOF
 
+set-workdir /root/nomad/acls
+
 exit 0

--- a/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-client-3
@@ -9,4 +9,6 @@ acl {
 }
 EOF
 
+set-workdir /root/nomad/acls
+
 exit 0

--- a/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/nomad-acls/setup-nomad-server-1
@@ -128,4 +128,6 @@ node {
 }
 EOF
 
+set-workdir /root/nomad/acls
+
 exit 0

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-1/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-1/setup-nomad-server-1
@@ -44,6 +44,15 @@ job "catalogue" {
   group "catalogue" {
     count = 1
 
+    network {
+      port "http" {
+        to = 8080
+      }
+      port "db" {
+        to = 3306
+      }
+    }
+
     restart {
       attempts = 10
       interval = "5m"
@@ -61,9 +70,7 @@ job "catalogue" {
         args = ["-port", "8080", "-DSN", "catalogue_user:default_password@tcp(127.0.0.1:3306)/socksdb"]
         hostname = "catalogue.service.consul"
         network_mode = "host"
-        port_map {
-          http = 8080
-        }
+        ports = ["http"]
       }
 
       service {
@@ -75,12 +82,6 @@ job "catalogue" {
       resources {
         cpu = 100 # Mhz
         memory = 128 # MB
-        network {
-          mbits = 10
-          port "http" {
-            static = 8080
-          }
-        }
       }
     } # - end app - #
 
@@ -94,9 +95,7 @@ job "catalogue" {
         command = "docker-entrypoint.sh"
         args = ["mysqld", "--bind-address", "127.0.0.1"]
         network_mode = "host"
-        port_map {
-          http = 3306
-        }
+        ports = ["db"]
       }
 
       env {
@@ -107,18 +106,12 @@ job "catalogue" {
       service {
         name = "catalogue-db"
         tags = ["db", "catalogue", "catalogue-db"]
-        port = "http"
+        port = "db"
       }
 
       resources {
         cpu = 100 # Mhz
         memory = 256 # MB
-        network {
-          mbits = 10
-          port "http" {
-            static = 3306
-          }
-        }
       }
 
     } # - end db - #
@@ -147,6 +140,12 @@ job "webserver-test" {
   group "webserver" {
     count = 2
 
+    network {
+      port "http" {
+        to = 80
+      }
+    }
+
     restart {
       attempts = 10
       interval = "5m"
@@ -161,9 +160,7 @@ job "webserver-test" {
       config {
         # "httpd" is not an allowed image
         image = "httpd"
-        port_map {
-          http = 80
-        }
+        ports = ["http"]
       }
 
       service {
@@ -175,10 +172,6 @@ job "webserver-test" {
       resources {
         cpu = 250 # Mhz
         memory = 512 # MB
-        network {
-          mbits = 10
-          port "http" {}
-        }
       }
     } # - end task - #
   } # - end group - #
@@ -205,6 +198,12 @@ job "website" {
   group "nginx" {
     count = 2
 
+    network {
+      port "http" {
+        to = 80
+      }
+    }
+
     restart {
       attempts = 10
       interval = "5m"
@@ -218,9 +217,7 @@ job "website" {
 
       config {
         image = "nginx:1.15.6"
-        port_map {
-          http = 80
-        }
+        ports = ["http"]
       }
 
       service {
@@ -232,16 +229,18 @@ job "website" {
       resources {
         cpu = 250 # Mhz
         memory = 512 # MB
-        network {
-          mbits = 10
-          port "http" {}
-        }
       }
     } # - end task - #
   } # - end group - #
 
   group "mongodb" {
     count = 2
+
+    network {
+      port "db" {
+        to = 27017
+      }
+    }
 
     restart {
       attempts = 10
@@ -256,24 +255,18 @@ job "website" {
 
       config {
         image = "mongo:3.4.3"
-        port_map {
-          http = 27017
-        }
+        ports = ["db"]
       }
 
       service {
         name = "mongodb-dev"
         tags = ["db", "mongodb", "dev"]
-        port = "http"
+        port = "db"
       }
 
       resources {
         cpu = 250 # Mhz
         memory = 512 # MB
-        network {
-          mbits = 10
-          port "http" {}
-        }
       }
     } # - end task - #
   } # - end group - #
@@ -301,6 +294,12 @@ job "website" {
   group "nginx" {
     count = 2
 
+    network {
+      port "http" {
+        to = 80
+      }
+    }
+
     restart {
       attempts = 10
       interval = "5m"
@@ -308,15 +307,13 @@ job "website" {
       mode = "delay"
     }
 
-    # - db - #
+    # - web - #
     task "nginx" {
       driver = "docker"
 
       config {
         image = "nginx:1.15.6"
-        port_map {
-          http = 80
-        }
+        ports = ["http"]
       }
 
       service {
@@ -328,16 +325,19 @@ job "website" {
       resources {
         cpu = 250 # Mhz
         memory = 1024 # MB
-        network {
-          mbits = 10
-          port "http" {}
-        }
+
       }
     } # - end task - #
   } # - end group - #
 
   group "mongodb" {
     count = 2
+
+    network {
+      port "db" {
+        to = 27017
+      }
+    }
 
     restart {
       attempts = 10
@@ -352,29 +352,25 @@ job "website" {
 
       config {
         image = "mongo:3.4.3"
-        port_map {
-          http = 27017
-        }
+        ports = ["db"]
       }
 
       service {
         name = "mongodb-qa"
         tags = ["db", "mongodb", "qa"]
-        port = "http"
+        port = "db"
       }
 
       resources {
         cpu = 250 # Mhz
         memory = 1024 # MB
-        network {
-          mbits = 10
-          port "http" {}
-        }
       }
     } # - end task - #
   } # - end group - #
 
 }
 EOF
+
+set-workdir /root/nomad/jobs
 
 exit 0

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-2/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-2/setup-nomad-server-1
@@ -1,3 +1,5 @@
 #!/bin/bash -l
 
+set-workdir /root/nomad/jobs
+
 exit 0

--- a/instruqt-tracks/nomad-governance/sentinel-policies/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/sentinel-policies/setup-nomad-server-1
@@ -66,4 +66,6 @@ main = rule {
 }
 EOF
 
+set-workdir /root/nomad/sentinel
+
 exit 0

--- a/instruqt-tracks/nomad-governance/track.yml
+++ b/instruqt-tracks/nomad-governance/track.yml
@@ -5,9 +5,9 @@ title: Nomad Enterprise Governance
 teaser: |
   Learn how to use Nomad Enterprise's governance capabilities including namespaces, resource quotas, and Sentinel policies.
 description: |-
-  This track will show you how to use Nomad Enterprise's governance capabilities including [Audit Logging](https://www.nomadproject.io/docs/enterprise#audit-logging), [Namespaces](https://learn.hashicorp.com/tutorials/nomad/namespaces), [Resource Quotas](https://learn.hashicorp.com/tutorials/nomad/quotas), [Sentinel Policies](https://learn.hashicorp.com/tutorials/nomad/sentinel), and [Cross-Namespace Queries](https://www.nomadproject.io/docs/enterprise#cross-namespace-queries).
+  This track will show you how to use Nomad Enterprise's governance capabilities including [Audit Logging](https://www.nomadproject.io/docs/enterprise#audit-logging), [Resource Quotas](https://learn.hashicorp.com/tutorials/nomad/quotas), [Sentinel Policies](https://learn.hashicorp.com/tutorials/nomad/sentinel), and [Cross-Namespace Queries](https://www.nomadproject.io/docs/enterprise#cross-namespace-queries).
 
-  You will also configure and use [Nomad ACLs](https://learn.hashicorp.com/tutorials/nomad/access-control) which are applicable to namespaces and resource quotas and required by Nomad Sentinel policies.
+  You will also configure and use [Namespaces](https://learn.hashicorp.com/tutorials/nomad/namespaces) and [Nomad ACLs](https://learn.hashicorp.com/tutorials/nomad/access-control). Namespaces are required when using resource quotas. ACLs are applicable to namespaces and resource quotas and are required by Nomad Sentinel policies.
 
   Before running this track, we suggest you run the [Nomad Basics](https://instruqt.com/hashicorp/tracks/nomad-basics) and [Nomad Simple Cluster](https://instruqt.com/hashicorp/tracks/nomad-simple-cluster) tracks.
 icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/nomad.png
@@ -229,7 +229,7 @@ challenges:
 
     Feel free throughout this track to inspect the audit logs on the server or any of the clients after running any Nomad commands on them. Or just inspect the audit logs after completing the track.
 
-    In the next challenge, you will configure Nomad Enterprise namespaces and resource quotas.
+    In the next challenge, you will configure Nomad namespaces and resource quotas.
   notes:
   - type: text
     contents: |-
@@ -237,7 +237,7 @@ challenges:
 
       With Nomad audit logging, enterprises can proactively identify access anomalies, ensure enforcement of their security policies, and diagnose cluster behavior by viewing preceding user operations.
 
-      In the next challenge, you will configure Nomad Enterprise namespaces and resource quotas.
+      In the next challenge, you will configure Nomad namespaces and resource quotas.
   tabs:
   - title: Config Files
     type: code
@@ -979,4 +979,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "9490140127686699643"
+checksum: "15715815439375908135"


### PR DESCRIPTION
This PR updates network stanzas in Nomad job specs to avoid deprecation warnings that started appearing in Nomad 1.0.  This includes moving `network` stanzas out of `resources` to the `group` level, removing `mbits`, and replaceing `port_map` with `ports`.