### PR TITLE
update job spec 3 tracks

### DIFF
--- a/instruqt-tracks/nomad-acls/run-the-servers-and-clients/setup-nomad-server-3
+++ b/instruqt-tracks/nomad-acls/run-the-servers-and-clients/setup-nomad-server-3
@@ -79,6 +79,7 @@ cd nomad
 #Create demo Job
 nomad init --short
 mv example.nomad redis.nomad
+sed -i "s/example/redis/g" redis.nomad
 
 sleep 15
 

--- a/instruqt-tracks/nomad-acls/track.yml
+++ b/instruqt-tracks/nomad-acls/track.yml
@@ -352,7 +352,7 @@ challenges:
     ```
     nomad node status
     ```
-    You should see the 2 client servers.
+    You should see the 2 client nodes.
 
     In the next challenge, you will see how the Nomad ACLs restrict what different users can do in Nomad.
   notes:
@@ -491,7 +491,7 @@ challenges:
     ```
     nomad acl token list
     ```
-    you should see a list with the two new tokens. You will also see the main bootstrap token we are using.
+    you should see a list with the two new tokens. You will also see the bootstrap token that we are using.
 
     We can now test the access of the team with their tokens.
 
@@ -499,7 +499,7 @@ challenges:
     `export NOMAD_TOKEN=<dev_token>`<br>
     replacing <dev_token/> with the value of `Secret ID` in the devro_token.txt file on the "Config Files" tab.
 
-    If you now run `nomad job status`, you should see the `redis` job listed again.  But, if you try to run `nomad job stop redis`, you should get a "Permission denied" error.
+    If you now run `nomad job status` on the "Server 2" tab, you should see the `redis` job listed again.  But, if you try to run `nomad job stop redis`, you should get a "Permission denied" error.
 
     Now let's test the access of the ops team:
 
@@ -507,13 +507,13 @@ challenges:
     `export NOMAD_TOKEN=<ops_token>`<br>
     replacing <ops_token/> with the value of `Secret ID` in the opsrw_token.txt file on the "Config Files" tab.
 
-    If you now run `nomad job status`, you should see the `redis` job listed again.
+    If you now run `nomad job status` on the "Server 3" tab, you should see the `redis` job listed again.
 
     If you try to run `nomad job stop redis`, the job should be stopped.
 
     If you try to run `cd nomad` followed by `nomad job run redis.nomad`, the job should be started again.
 
-    As you can see, the ACL permissions can be adjusted in many ways.  We recommended that you read up further about the policies in the [Nomad Access Control](https://www.nomadproject.io/guides/security/acl.html) guide.
+    As you can see, the ACL permissions can be adjusted in many ways.  We recommend that you read up further about the policies in the [Nomad Access Control](https://www.nomadproject.io/guides/security/acl.html) guide.
 
     Congratulations on finishing the Nomad ACLs track!
   notes:
@@ -547,4 +547,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 1800
-checksum: "9318739303332376960"
+checksum: "13581595256840021460"

--- a/instruqt-tracks/nomad-basics/nomad-cli/setup-nomad-server
+++ b/instruqt-tracks/nomad-basics/nomad-cli/setup-nomad-server
@@ -1,33 +1,12 @@
 #!/bin/bash -l
 
-cat <<-EOF > /root/redis.nomad
-job "redis" {
-  datacenters = ["dc1"]
+# Generate short version of example job
+nomad job init --short
 
-  group "cache" {
-    task "redis" {
-      driver = "docker"
+# Change name to redis.nomad
+mv example.nomad redis.nomad
 
-      config {
-        image = "redis:3.2"
-
-        port_map {
-          db = 6379
-        }
-      }
-
-      resources {
-        cpu    = 500
-        memory = 256
-
-        network {
-          mbits = 10
-          port  "db"  {}
-        }
-      }
-    }
-  }
-}
-EOF
+# Change name of job
+sed -i "s/example/redis/g" redis.nomad
 
 exit 0

--- a/instruqt-tracks/nomad-basics/track.yml
+++ b/instruqt-tracks/nomad-basics/track.yml
@@ -14,8 +14,8 @@ tags:
 - basics
 owner: hashicorp
 developers:
-- rjackson@hashicorp.com
 - roger@hashicorp.com
+- rjackson@hashicorp.com
 private: false
 published: true
 show_timer: true
@@ -254,4 +254,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "14512621176357453077"
+checksum: "8075692714081613461"

--- a/instruqt-tracks/nomad-simple-cluster/track.yml
+++ b/instruqt-tracks/nomad-simple-cluster/track.yml
@@ -255,11 +255,11 @@ challenges:
   assignment: |-
     Since your Redis database has been getting a lot of traffic, you've decided to run more instances of it to handle the load.
 
-    Let's edit the example.nomad file on the "Job Spec" tab to update the `count` of the job's task group, setting it to 3. Do this  between the `group` and `task` stanzas so that you end up with:
+    Let's edit the example.nomad file on the "Job Spec" tab to set the `count` of the job's task group to 3. Do this immediately under the `group` stanza header and add a blank line after the new line so that you end up with:
     ```
     group "cache" {
       count = 3
-      task "redis" {
+
     ```
     Once you have finished modifying the job specification, click the disk icon above the file to save it.
 
@@ -323,4 +323,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 1200
-checksum: "9840622058738458333"
+checksum: "16704014845656351954"


### PR DESCRIPTION
This updates the simple example/redis job spec used in 3 tracks to avoid deprecation warnings.  The tracks are:

1. https://play.instruqt.com/hashicorp/tracks/nomad-basics
2. https://play.instruqt.com/hashicorp/tracks/nomad-simple-cluster
3. https://play.instruqt.com/hashicorp/tracks/nomad-acls

In the second track, the job spec was already the one initialized by `nomad job. init --short`, but since that job is slightly different in Nomad 1.0.x, I made a change to track.yml to adjust where `count = 3` is added later.

I also made some minor edits in track.yml files of some of these tracks to clarify instructions.

Note that I also validated that https://play.instruqt.com/hashicorp/tracks/nomad-multi-server-cluster works correctly withoug any deprecation warnings, so it did not need any changes.