### PR TITLE
remove deprecation warnings from update-strategies track

### DIFF
--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/setup-nomad-server-1
@@ -63,15 +63,19 @@ job "nginx" {
 
   group "nginx" {
 
+    network {
+      port "http" {
+        static = 8080
+        to = 80
+      }
+    }
+
     task "nginx" {
       driver = "docker"
 
       config {
         image = "nginx"
-
-        port_map {
-          http = 80
-        }
+        ports = ["http"]
 
         volumes = [
           "local:/etc/nginx/conf.d",
@@ -130,16 +134,6 @@ EOT
         destination   = "local/load-balancer.conf"
         change_mode   = "signal"
         change_signal = "SIGHUP"
-      }
-
-      resources {
-        network {
-          mbits = 10
-
-          port "http" {
-            static = 8080
-          }
-        }
       }
 
       service {

--- a/instruqt-tracks/nomad-update-strategies/track.yml
+++ b/instruqt-tracks/nomad-update-strategies/track.yml
@@ -171,20 +171,22 @@ challenges:
     `<br>
     Later, when we do a blue-green deployment, we will see that the new "green" deployments will also be spread evenly across the 3 Nomad clients.
 
-    The "chat-app" task runs on a dynamic port selected by Nomad; that port is mapped to port 5000 inside the task group's "network" stanza:<br>
-    `
+    The "chat-app" task runs on a dynamic port selected by Nomad; that port is mapped to port 5000 inside the task group's "network" stanza:
+
+    ```
     network {
       mode = "bridge"
       port "http" {
         to = 5000
       }
     }
-    `<br>
+    ```
 
     The NGINX load balancer that you will deploy after the "chat-app" job will automatically add a route for each instance of the chat app because of the "template" stanza within the "nginx.nomad" job specification file.
 
-    Finally, the "chat-app" task group uses Consul Connect [sidecar proxies](https://www.consul.io/docs/connect/proxies.html) to talk to the MongoDB database using mutual Transport Layer Security (mTLS) certificates. This is implemented by this stanza:<br>
-    `
+    Finally, the "chat-app" task group uses Consul Connect [sidecar proxies](https://www.consul.io/docs/connect/proxies.html) to talk to the MongoDB database using mutual Transport Layer Security (mTLS) certificates. This is implemented by this stanza:
+
+    ```
     connect {
       sidecar_service {
         tags = ["chat-app-proxy"]
@@ -196,7 +198,8 @@ challenges:
         }
       }
     }
-    `<br>
+    ````
+
     The exact same stanza will be used in versions of the job that run the containerized versions of the application with the [Docker](https://www.nomadproject.io/docs/drivers/docker/) task driver. Nomad and Consul Connect work equally well with non-containerized and containerized applications.
 
     Run the "chat-app-light-binary.nomad" job on the "Server" tab with this command:
@@ -710,4 +713,4 @@ challenges:
     port: 8080
   difficulty: basic
   timelimit: 600
-checksum: "14061721018299607100"
+checksum: "482772090237461827"


### PR DESCRIPTION
Update job specs in https://play.instruqt.com/hashicorp/tracks/nomad-update-strategies to get rid of some deprecation warnings that started showing up after moving to Nomad 1.0.