### PR TITLE
update stateful storage tracks

### DIFF
--- a/instruqt-tracks/nomad-and-csi-plugins-gcp/deploy-mysql/setup-cloud-client
+++ b/instruqt-tracks/nomad-and-csi-plugins-gcp/deploy-mysql/setup-cloud-client
@@ -10,6 +10,12 @@ job "mysql-server" {
   group "mysql-server" {
     count = 1
 
+    network {
+      port "db" {
+        static = 3306
+      }
+    }
+
     volume "mysql" {
       type      = "csi"
       read_only = false
@@ -39,21 +45,12 @@ job "mysql-server" {
       config {
         image = "rberlind/mysql-demo:latest"
         args = ["--datadir", "/srv/mysql"]
-
-        port_map {
-          db = 3306
-        }
+        ports = ["db"]
       }
 
       resources {
         cpu    = 500
         memory = 1024
-
-        network {
-          port "db" {
-            static = 3306
-          }
-        }
       }
 
       service {

--- a/instruqt-tracks/nomad-and-csi-plugins-gcp/track.yml
+++ b/instruqt-tracks/nomad-and-csi-plugins-gcp/track.yml
@@ -257,7 +257,7 @@ challenges:
     type = "csi"
     id = "mysql"
     name = "mysql"
-    external_id = "projects/p-win27zef7iuixs40ujimrnpitdbj/zones/europe-west"
+    external_id = "projects/p-win27zef7iuixs40ujimrnpitdbj/zones/europe-west/disks/mysql"
     access_mode = "single-node-writer"
     attachment_mode = "file-system"
     plugin_id = "gcepd"
@@ -416,14 +416,14 @@ challenges:
 
     You are now ready to destroy the database. Please run the following command on the "Nomad Server" tab to stop and purge the job from the Nomad cluster:
     ```
-    nomad stop -purge mysql-server
+    nomad job stop -purge mysql-server
     ```
 
     Verify the `mysql` job is no longer running in the cluster:
     ```
     nomad job status mysql
     ```
-    You should not see the `mysql` job.
+    You should not see the `mysql-server` job.
 
     Using the same "mysql.nomad" job file that you used in the last challenge, redeploy the database:
     ```
@@ -487,4 +487,4 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 1200
-checksum: "7175045922606233527"
+checksum: "2373513194976113665"

--- a/instruqt-tracks/nomad-and-portworx/deploy-mysql/setup-cloud-client
+++ b/instruqt-tracks/nomad-and-portworx/deploy-mysql/setup-cloud-client
@@ -11,6 +11,12 @@ job "mysql-server" {
   group "mysql-server" {
     count = 1
 
+    network {
+      port "db" {
+        static = 3306
+      }
+    }
+
     task "mysql-server" {
       driver = "docker"
 
@@ -20,10 +26,7 @@ job "mysql-server" {
 
       config {
         image = "rberlind/mysql-demo:latest"
-
-        port_map {
-          db = 3306
-        }
+        ports = ["db"]
 
         volumes = [
           "mysql:/var/lib/mysql",
@@ -35,12 +38,6 @@ job "mysql-server" {
       resources {
         cpu    = 500
         memory = 1024
-
-        network {
-          port "db" {
-            static = 3306
-          }
-        }
       }
 
       service {

--- a/instruqt-tracks/nomad-and-portworx/install-portworx/setup-cloud-client
+++ b/instruqt-tracks/nomad-and-portworx/install-portworx/setup-cloud-client
@@ -11,6 +11,12 @@ job "portworx" {
   group "portworx" {
     count = 2
 
+    network {
+      port "portworx" {
+        static = 9015
+      }
+    }
+
     constraint {
       operator  = "distinct_hosts"
       value     = "true"
@@ -60,7 +66,7 @@ job "portworx" {
       # container config
       config {
         image        = "portworx/oci-monitor:2.6.2"
-        network_mode = "host"
+        ports = ["portworx"]
         ipc_mode = "host"
         privileged = true
 
@@ -91,13 +97,6 @@ job "portworx" {
       resources {
         cpu    = 1024
         memory = 2048
-
-        network {
-          mbits = 100
-          port "portworx" {
-            static = "9015"
-          }
-        }
       }
     }
   }

--- a/instruqt-tracks/nomad-and-portworx/track.yml
+++ b/instruqt-tracks/nomad-and-portworx/track.yml
@@ -441,4 +441,4 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 600
-checksum: "6852385657607390552"
+checksum: "11590941552426721846"

--- a/instruqt-tracks/nomad-host-volumes/deploy-mysql/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-host-volumes/deploy-mysql/setup-nomad-server-1
@@ -8,6 +8,12 @@ job "mysql-server" {
   group "mysql-server" {
     count = 1
 
+    network {
+      port "db" {
+        static = 3306
+      }
+    }
+
     volume "mysql_volume" {
       type      = "host"
       read_only = false
@@ -29,21 +35,12 @@ job "mysql-server" {
 
       config {
         image = "rberlind/mysql-demo:latest"
-
-        port_map {
-          db = 3306
-        }
+        ports = ["db"]
       }
 
       resources {
         cpu    = 500
         memory = 1024
-
-        network {
-          port "db" {
-            static = 3306
-          }
-        }
       }
 
       service {

--- a/instruqt-tracks/nomad-host-volumes/track.yml
+++ b/instruqt-tracks/nomad-host-volumes/track.yml
@@ -411,4 +411,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 600
-checksum: "16099933420632636170"
+checksum: "4363969336894737468"


### PR DESCRIPTION
Update the 3 stateful storage Instruqt tracks to avoid deprecation warnings related to task-level network stanzas since upgrading to 1.0.