### PR TITLE
make tracks with GCP projects private

### DIFF
--- a/instruqt-tracks/nomad-and-csi-plugins-gcp/track.yml
+++ b/instruqt-tracks/nomad-and-csi-plugins-gcp/track.yml
@@ -32,7 +32,7 @@ owner: hashicorp
 developers:
 - roger@hashicorp.com
 - tharris@hashicorp.com
-private: false
+private: true
 published: true
 show_timer: true
 challenges:

--- a/instruqt-tracks/nomad-and-portworx/track.yml
+++ b/instruqt-tracks/nomad-and-portworx/track.yml
@@ -28,7 +28,7 @@ tags:
 owner: hashicorp
 developers:
 - roger@hashicorp.com
-private: false
+private: true
 published: true
 show_timer: true
 challenges:

--- a/instruqt-tracks/nomad-on-windows/track.yml
+++ b/instruqt-tracks/nomad-on-windows/track.yml
@@ -19,7 +19,7 @@ tags:
 owner: hashicorp
 developers:
 - roger@hashicorp.com
-private: false
+private: true
 published: true
 show_timer: true
 challenges:


### PR DESCRIPTION
Instruqt reported crypto mining on those tracks:
nomad-on-windows
nomad-and-csi-plugins-gcp
nomad-and-portworx