### PR TITLE
Update the track config to add the correct server name

### DIFF
--- a/instruqt-tracks/nomad-simple-cluster/run-the-server-and-clients/setup-nomad-server
+++ b/instruqt-tracks/nomad-simple-cluster/run-the-server-and-clients/setup-nomad-server
@@ -8,7 +8,7 @@ cat <<-EOF > /root/nomad/server.hcl
 data_dir = "/tmp/nomad/server1"
 
 # Give the agent a unique name. Defaults to hostname
-name = "server"
+name = "nomad-server"
 
 # Enable the server
 server {


### PR DESCRIPTION
The server name in the track was set to server but the clients were configured to use nomad-server so they did not connect.