### PR TITLE
Remove test for Nomad on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -548,46 +548,6 @@ jobs:
               echo "Instruqt track test failed three times."
               exit 1
             fi
-  instruqt-test-nomad-on-windows:
-    docker:
-      - image: docker.mirror.hashicorp.services/ubuntu:latest
-    steps:
-      - checkout
-      - run:
-          name: Run Instruqt Test
-          command: |
-            VERSION=$INSTRUQT_VERSION
-            apt -y update
-            apt -y install wget unzip
-            wget https://github.com/instruqt/cli/releases/download/${VERSION}/instruqt-linux-${VERSION}.zip -O /tmp/instruqt.zip
-            cd /tmp
-            unzip instruqt.zip
-            cp instruqt /usr/local/bin/instruqt
-            chmod +x /usr/local/bin/instruqt
-            echo "yes" | instruqt version
-            RETVAL=$?
-            if [[ $RETVAL -ne 0 ]]; then
-              echo "Instruqt is not installed correctly."
-              exit 1
-            else
-              echo "Instruqt is installed and updated to most recent version."
-            fi
-            cd /root/project/instruqt-tracks/nomad-on-windows
-            echo "Running instruqt track push..."
-            instruqt track push --force
-            echo "Running instruqt track test..."
-            # Retry instruqt track test up to 3 times
-            n=0
-            until [ $n -ge 3 ]
-            do
-              instruqt track test --skip-fail-check && break
-              n=$[$n+1]
-              sleep 60
-            done
-            if [ $n -ge 3 ]; then
-              echo "Instruqt track test failed three times."
-              exit 1
-            fi
   instruqt-test-nomad-federation:
     docker:
       - image: docker.mirror.hashicorp.services/ubuntu:latest
@@ -714,12 +674,6 @@ workflows:
           filters:
             branches:
               only: main
-      - instruqt-test-nomad-on-windows:
-          requires:
-            - instruqt-validate
-          filters:
-            branches:
-              only: main
       - instruqt-test-nomad-federation:
           requires:
             - instruqt-validate
@@ -773,9 +727,6 @@ workflows:
           requires:
             - instruqt-validate
       - instruqt-test-nomad-governance:
-          requires:
-            - instruqt-validate
-      - instruqt-test-nomad-on-windows:
           requires:
             - instruqt-validate
       - instruqt-test-nomad-federation:


### PR DESCRIPTION
The Nomad on Windows lab is somewhat unreliable and is not actually used in the workshops.
So, it does not need nightly testing