### PR TITLE
client addr on consul server and client set to local IP

### DIFF
--- a/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-client-1
@@ -25,7 +25,6 @@ cat <<-EOF > /root/nomad/consul-client1.json
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
   "retry_join": [
     "nomad-server-1",
     "nomad-server-2",

--- a/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-client-2
+++ b/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-client-2
@@ -25,7 +25,6 @@ cat <<-EOF > /root/nomad/consul-client2.json
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
   "retry_join": [
     "nomad-server-1",
     "nomad-server-2",

--- a/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-server-1
@@ -27,7 +27,6 @@ cat <<-EOF > /root/nomad/consul-server1.json
   "data_dir": "/tmp/consul/server1",
   "node_name": "server1",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
   "bootstrap_expect": 3,
   "retry_join": [
     "nomad-server-2",

--- a/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-server-2
+++ b/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-server-2
@@ -27,7 +27,6 @@ cat <<-EOF > /root/nomad/consul-server2.json
   "data_dir": "/tmp/consul/server2",
   "node_name": "server2",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
   "bootstrap_expect": 3,
   "retry_join": [
     "nomad-server-1",

--- a/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-server-3
+++ b/instruqt-tracks/nomad-multi-server-cluster/automatic-clustering-with-consul/setup-nomad-server-3
@@ -27,7 +27,6 @@ cat <<-EOF > /root/nomad/consul-server3.json
   "data_dir": "/tmp/consul/server3",
   "node_name": "server3",
   "bind_addr": "{{ GetInterfaceIP \"ens4\" }}",
-  "client_addr": "{{ GetInterfaceIP \"ens4\" }}",
   "bootstrap_expect": 3,
   "retry_join": [
     "nomad-server-1",


### PR DESCRIPTION
By setting client_addr to use ens4 (in this case) we set the client to be bound to the local ip and not to the loopback address.   This makes commands like consul members fail which also makes the step joining nomad cluster using consul fail as well as they cannot access the local api/client (127.0.0.1:8500).

By removing this stanza it will default to bind to the loopback address.

https://www.consul.io/docs/agent/options#_client