### PR TITLE
update to Nomad 1.2.4

### DIFF
--- a/instruqt-tracks/nomad-acls/config.yml
+++ b/instruqt-tracks/nomad-acls/config.yml
@@ -1,22 +1,22 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-server-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-server-3
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-basics/config.yml
+++ b/instruqt-tracks/nomad-basics/config.yml
@@ -1,6 +1,6 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-consul-connect/config.yml
+++ b/instruqt-tracks/nomad-consul-connect/config.yml
@@ -1,19 +1,19 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500

--- a/instruqt-tracks/nomad-host-volumes/config.yml
+++ b/instruqt-tracks/nomad-host-volumes/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500

--- a/instruqt-tracks/nomad-integration-with-vault/config.yml
+++ b/instruqt-tracks/nomad-integration-with-vault/config.yml
@@ -1,21 +1,21 @@
 version: "2"
 virtualmachines:
 - name: hashistack-server
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-server:8500
     VAULT_ADDR: http://127.0.0.1:8200/
   machine_type: n1-standard-1
 - name: hashistack-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-client-1:8500
     VAULT_ADDR: http://active.vault.service.consul:8200/
   machine_type: n1-standard-1
 - name: hashistack-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-client-2:8500

--- a/instruqt-tracks/nomad-job-placement/config.yml
+++ b/instruqt-tracks/nomad-job-placement/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-2
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-3:8500

--- a/instruqt-tracks/nomad-monitoring/config.yml
+++ b/instruqt-tracks/nomad-monitoring/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-server:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-3:8500

--- a/instruqt-tracks/nomad-multi-server-cluster/config.yml
+++ b/instruqt-tracks/nomad-multi-server-cluster/config.yml
@@ -1,31 +1,31 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-server-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-2:8500
   machine_type: n1-standard-1
 - name: nomad-server-3
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-3:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500

--- a/instruqt-tracks/nomad-simple-cluster/config.yml
+++ b/instruqt-tracks/nomad-simple-cluster/config.yml
@@ -1,14 +1,14 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-update-strategies/config.yml
+++ b/instruqt-tracks/nomad-update-strategies/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-9-1
+  image: instruqt-hashicorp/hashistack-0-13-0
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-3:8500


### PR DESCRIPTION
Update most Nomad workshop tracks to Nomad 1.2.4
The exceptions at this point are the nomad-governance and nomad-federation tracks which use Nomad Enterprise. Updating them would require us to provide students with a Nomad Enterprise license.  Doing that is possible, but needs to be correctly figured out and planned. I will work on that more this week.