### PR TITLE
fix nomad-update-strategies track

### DIFF
--- a/instruqt-tracks/nomad-update-strategies/blue-green-deployment/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/blue-green-deployment/check-nomad-server-1
@@ -6,10 +6,11 @@ grep -q "cd\s\+/root/nomad/jobs" /root/.bash_history || fail-message "You have n
 
 grep -q "nomad\s\+job\s\+plan\s\+chat-app-light-docker.nomad" /root/.bash_history || fail-message "You have not planned the blue/green deployment of the chat-app job on the Nomad server yet."
 
-grep -q "nomad\s\+job\s\+run\s\+chat-app-light-docker.nomad" /root/.bash_history || fail-message "You have not run the blue/green deployment of the chat-app job on the Nomad server yet."
+grep -q "nomad\s\+job\s\+run.*chat-app-light-docker.nomad" /root/.bash_history || fail-message "You have not run the blue/green deployment of the chat-app job on the Nomad server yet."
 
 grep -q "nomad\s\+job\s\+status\s\+chat-app" /root/.bash_history || fail-message "You have not checked the status of the chat-app job on the Nomad server yet."
 
-grep -q "nomad\s\+deployment\s\+promote" /root/.bash_history || fail-message "You have not promoted the blue/green deployment of the chat-app job on the Nomad server yet."
+# Comment this out to allow Nomad UI to be used
+# grep -q "nomad\s\+deployment\s\+promote" /root/.bash_history || fail-message "You have not promoted the blue/green deployment of the chat-app job on the Nomad server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/blue-green-deployment/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/blue-green-deployment/solve-nomad-server-1
@@ -11,7 +11,7 @@ cd /root/nomad/jobs
 nomad job plan chat-app-light-docker.nomad
 
 # Run a blue/green deployment of the chat-app job
-nomad job run chat-app-light-docker.nomad
+nomad job run -detach chat-app-light-docker.nomad
 
 # Sleep
 sleep 180

--- a/instruqt-tracks/nomad-update-strategies/canary-deployment/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/canary-deployment/check-nomad-server-1
@@ -6,10 +6,11 @@ grep -q "cd\s\+/root/nomad/jobs" /root/.bash_history || fail-message "You have n
 
 grep -q "nomad\s\+job\s\+plan\s\+chat-app-dark-docker.nomad" /root/.bash_history || fail-message "You have not planned the canary deployment of the chat-app job on the Nomad server yet."
 
-grep -q "nomad\s\+job\s\+run\s\+chat-app-dark-docker.nomad" /root/.bash_history || fail-message "You have not run the canary deployment of the chat-app job on the Nomad server yet."
+grep -q "nomad\s\+job\s\+run.*chat-app-dark-docker.nomad" /root/.bash_history || fail-message "You have not run the canary deployment of the chat-app job on the Nomad server yet."
 
 grep -q "nomad\s\+job\s\+status\s\+chat-app" /root/.bash_history || fail-message "You have not checked the status of the canary deployment of the chat-app job on the Nomad server yet."
 
-grep -q "nomad\s\+deployment\s\+fail" /root/.bash_history || fail-message "You have not failed the canary deployment of the chat-app job on the Nomad server yet."
+# Comment out so Nomad UI can also be used.
+#grep -q "nomad\s\+deployment\s\+fail" /root/.bash_history || fail-message "You have not failed the canary deployment of the chat-app job on the Nomad server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/canary-deployment/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/canary-deployment/solve-nomad-server-1
@@ -11,7 +11,7 @@ cd /root/nomad/jobs
 nomad job plan chat-app-dark-docker.nomad
 
 # Run the job
-nomad job run chat-app-dark-docker.nomad
+nomad job run -detach chat-app-dark-docker.nomad
 
 # Sleep
 sleep 120

--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/check-nomad-server-1
@@ -4,14 +4,14 @@ set -e
 
 grep -q "cd\s\+/root/nomad/jobs" /root/.bash_history || fail-message "You have not navigated to /root/nomad/jobs on the Nomad server yet."
 
-grep -q "nomad\s\+job\s\+run\s\+mongodb.nomad" /root/.bash_history || fail-message "You have not run the mongodb.nomad job on the Nomad server yet."
+grep -q "nomad\s\+job\s\+run.*mongodb.nomad" /root/.bash_history || fail-message "You have not run the mongodb.nomad job on the Nomad server yet."
 
 grep -q "nomad\s\+job\s\+status\s\+mongodb" /root/.bash_history || fail-message "You have not checked the status of the mongodb job with the CLI on the Nomad server yet."
 
-grep -q "nomad\s\+job\s\+run\s\+chat-app-light-binary.nomad" /root/.bash_history || fail-message "You have not run the chat-app-light-binary.nomad job on the Nomad server yet."
+grep -q "nomad\s\+job\s\+run.*chat-app-light-binary.nomad" /root/.bash_history || fail-message "You have not run the chat-app-light-binary.nomad job on the Nomad server yet."
 
 grep -q "nomad\s\+job\s\+status\s\+chat-app" /root/.bash_history || fail-message "You have not checked the status of the chat-app job on the Nomad server yet."
 
-grep -q "nomad\s\+job\s\+run\s\+nginx.nomad" /root/.bash_history || fail-message "You have not run the nginx.nomad job on the Nomad server yet."
+grep -q "nomad\s\+job\s\+run.*nginx.nomad" /root/.bash_history || fail-message "You have not run the nginx.nomad job on the Nomad server yet."
 
 exit 0

--- a/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/deploy-the-jobs/solve-nomad-server-1
@@ -8,7 +8,7 @@ set -o history
 cd /root/nomad/jobs
 
 # Run mongodb Job
-nomad job run mongodb.nomad
+nomad job run -detach mongodb.nomad
 
 # Sleep
 sleep 30
@@ -17,7 +17,7 @@ sleep 30
 nomad job status mongodb
 
 # Run chat-app Job
-nomad job run chat-app-light-binary.nomad
+nomad job run -detach chat-app-light-binary.nomad
 
 # Sleep
 sleep 120
@@ -26,7 +26,7 @@ sleep 120
 nomad job status chat-app
 
 # Run nginx Job
-nomad job run nginx.nomad
+nomad job run -detach nginx.nomad
 
 # Sleep
 sleep 30

--- a/instruqt-tracks/nomad-update-strategies/rolling-update/check-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/rolling-update/check-nomad-server-1
@@ -6,7 +6,7 @@ grep -q "cd\s\+/root/nomad/jobs" /root/.bash_history || fail-message "You have n
 
 grep -q "nomad\s\+job\s\+plan\s\+chat-app-dark-binary.nomad" /root/.bash_history || fail-message "You have not planned a new deployment of the chat-app job on the Nomad server yet."
 
-grep -q "nomad\s\+job\s\+run\s\+chat-app-dark-binary.nomad" /root/.bash_history || fail-message "You have not run the rolling update of the chat-app job on the Nomad server yet."
+grep -q "nomad\s\+job\s\+run.*chat-app-dark-binary.nomad" /root/.bash_history || fail-message "You have not run the rolling update of the chat-app job on the Nomad server yet."
 
 grep -q "nomad\s\+job\s\+status\s\+chat-app" /root/.bash_history || fail-message "You have not checked the status of the rolling update of the chat-app job on the Nomad server yet."
 

--- a/instruqt-tracks/nomad-update-strategies/rolling-update/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-update-strategies/rolling-update/solve-nomad-server-1
@@ -11,7 +11,7 @@ cd /root/nomad/jobs
 nomad job plan chat-app-dark-binary.nomad
 
 # Run chat-app.nomad Job
-nomad job run chat-app-dark-binary.nomad
+nomad job run -detach chat-app-dark-binary.nomad
 
 # Sleep
 sleep 120

--- a/instruqt-tracks/nomad-update-strategies/track.yml
+++ b/instruqt-tracks/nomad-update-strategies/track.yml
@@ -713,4 +713,4 @@ challenges:
     port: 8080
   difficulty: basic
   timelimit: 600
-checksum: "11751966276259963252"
+checksum: "6980574927668619047"


### PR DESCRIPTION
Fix the nomad-update-strategies track by adding `-detach` to `nomad job run` commands to prevent those commands from entering permanent monitor state when waiting for canaries to be promoted or failed.