### PR TITLE
Update to nomad 1.2.4

### DIFF
--- a/instruqt-tracks/nomad-acls/config.yml
+++ b/instruqt-tracks/nomad-acls/config.yml
@@ -1,22 +1,22 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-server-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-server-3
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-basics/config.yml
+++ b/instruqt-tracks/nomad-basics/config.yml
@@ -1,6 +1,6 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-consul-connect/config.yml
+++ b/instruqt-tracks/nomad-consul-connect/config.yml
@@ -1,19 +1,19 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500

--- a/instruqt-tracks/nomad-governance/config.yml
+++ b/instruqt-tracks/nomad-governance/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-3:8500

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-2/check-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-2/check-nomad-server-1
@@ -8,9 +8,9 @@ grep -q "export NOMAD_TOKEN=\$(cat /root/nomad/acls/alice-token.txt | grep Secre
 
 grep -q "nomad quota status dev" /root/.bash_history || fail-message "You have not checked the status of the dev resoure quota on the Server yet."
 
-grep -q "nomad job run website-dev.nomad" /root/.bash_history || fail-message "You have not run the website-dev.nomad job on the Server yet."
+grep -q "nomad job run.*website-dev.nomad" /root/.bash_history || fail-message "You have not run the website-dev.nomad job on the Server yet."
 
-grep -q "nomad job status -namespace=dev website" /root/.bash_history || fail-message "You have not checked the status of the website job in the dev namespace on the Server yet."
+#grep -q "nomad job status -namespace=dev website" /root/.bash_history || fail-message "You have not checked the status of the website job in the dev namespace on the Server yet."
 
 dev_quota_checks=$(grep "nomad quota status dev" /root/.bash_history | wc -l)
 if [ $dev_quota_checks -lt 2 ]; then
@@ -21,7 +21,7 @@ grep -q "export NOMAD_TOKEN=\$(cat /root/nomad/acls/bob-token.txt | grep Secret 
 
 grep -q "nomad quota status qa" /root/.bash_history || fail-message "You have not checked the status of the qa resource quota on the Server yet."
 
-grep -q "nomad job run website-qa.nomad" /root/.bash_history || fail-message "You have not run the website-qa.nomad job on the Server yet."
+grep -q "nomad job run.*website-qa.nomad" /root/.bash_history || fail-message "You have not run the website-qa.nomad job on the Server yet."
 
 grep -q "nomad job stop -namespace=qa webserver-test" /root/.bash_history || fail-message "You have not stopped the webserver-test job on the Server yet."
 

--- a/instruqt-tracks/nomad-governance/run-nomad-jobs-2/solve-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/run-nomad-jobs-2/solve-nomad-server-1
@@ -14,13 +14,13 @@ export NOMAD_TOKEN=$(cat /root/nomad/acls/alice-token.txt | grep Secret | cut -d
 nomad quota status dev
 
 # Run the website-dev.nomad job
-nomad job run website-dev.nomad
+nomad job run -detach website-dev.nomad
 
 # Sleep
 sleep 30
 
 # Check the status of the website job in the dev namespace
-nomad job status -namespace=dev website
+# nomad job status -namespace=dev website
 
 # Check the dev resource quota again
 nomad quota status dev
@@ -32,7 +32,7 @@ export NOMAD_TOKEN=$(cat /root/nomad/acls/bob-token.txt | grep Secret | cut -d' 
 nomad quota status qa
 
 # Run the website-qa.nomad job
-nomad job run website-qa.nomad
+nomad job run -detach website-qa.nomad
 
 # Sleep
 sleep 30

--- a/instruqt-tracks/nomad-governance/track.yml
+++ b/instruqt-tracks/nomad-governance/track.yml
@@ -860,11 +860,7 @@ challenges:
     nomad job run website-dev.nomad
     ```
 
-    After waiting 30 seconds, check the status of the job with this command:
-    ```
-    nomad job status -namespace=dev website
-    ```
-    Note that you need to specify the namespace since job names are not unique across multiple namespaces.
+    After about 30 seconds, you should see status indicating that 2 healthy allocations were placed for both of the job's task groups.
 
     You should see 4 allocations running at the bottom. You can also check the status of the "website" job in the "dev" namespace in the Nomad UI after providing a suitable ACL token after selecting the "ACL Tokens" menu; we recommend using Charlie's token from the charlie-token.txt file in the /root/nomad/acls directory.
 
@@ -927,17 +923,31 @@ challenges:
           * Dimension "memory" exhausted on 1 nodes
           * Quota limit hit "memory exhausted (5120 needed > 4100 limit)"
         Evaluation "f94e7499" waiting for additional capacity to place remainder
+
+        Deployment "ecfe5ffc" in progress...
+
+        2022-01-20T18:25:02Z
+        ID          = ecfe5ffc
+        Job ID      = website
+        Job Version = 0
+        Status      = running
+        Description = Deployment is running
+
+        Deployed
+        Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
+        mongodb     2        1       1        0          2022-01-20T18:32:41Z
+        nginx       2        2       2        0          2022-01-20T18:32:40Z
     ```
 
     Note that the Nomad failed to place 2 allocations because the running job and the four allocations of the new job would need a total of 5,120MB which is greater than the 4,096MB limit of the "qa" resource quota. (Sometimes, the message might say Nomad failed to place 1 allocation; and if you inspect the job in the Nomad UI, you might actually see 3 allocations running.)
 
     You can also select the "qa" namespace in the Nomad UI, select the "website" in it, and confirm that only 3 of the 4 allocations of the "website" job are running while 1 of them is queued. The fact that the allocation is currently queued rather than failed is important; this means that it could still be deployed if extra memory became available within the "qa" namespace or if the memory limit of the "qa" resource quota were increased.
 
-    To see this actually happen, stop the "webserver-test" job by running this command on the "Server" tab:
+    To see this actually happen, type `<ctrl>-c` to exit the monitor that the `nomad job run` command started and stop the "webserver-test" job by running this command on the "Server" tab:
     ```
     nomad job stop -namespace=qa webserver-test
     ```
-    and quickly switch back to the Nomad UI. Over the next 15-30 seconds, you should see the "Placed" number and then the "Healthy" number both change to 4, showing that Nomad completed the deployment of the "website" job in the "qa" namespace after extra memory was made available by stopping the "webserver-test" job in the same namespace.
+    Then quickly switch back to the Nomad UI. Over the next 15-30 seconds, you should see the "Placed" number and then the "Healthy" number both change to 4, showing that Nomad completed the deployment of the "website" job in the "qa" namespace after extra memory was made available by stopping the "webserver-test" job in the same namespace.
 
     Recall from the first challenge that the total capacity of the 3 Nomad clients in your cluster is 11.25GB of memory and 6,900MHz of CPU capacity. So, your cluster ostensibly has enough memory on the 3 Nomad clients to run both the "website" and the "webserver-test" jobs in the "qa" namespace along with the "website" job in the "dev" namespace and the "catalogue" job in the "default" namespace.
 
@@ -979,4 +989,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 900
-checksum: "10769221864496727653"
+checksum: "10767316440491419938"

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-1
@@ -35,6 +35,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-client1.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1",

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-2
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-2
@@ -35,6 +35,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-client2.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2",

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-3
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-client-3
@@ -35,6 +35,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-client3.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client3",
   "node_name": "client3",

--- a/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-server-1
+++ b/instruqt-tracks/nomad-governance/verify-nomad-cluster-health/setup-nomad-server-1
@@ -24,6 +24,7 @@ name = "server1"
 server {
   enabled = true
   bootstrap_expect = 1
+  license_path = "/var/nomad-license.hclic"
 }
 
 # Consul configuration
@@ -44,6 +45,7 @@ name = "server1"
 server {
   enabled = true
   bootstrap_expect = 1
+  license_path = "/var/nomad-license.hclic"
 }
 
 # Consul configuration
@@ -56,6 +58,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-server1.json
 {
   "server": true,
+  "license_path": "/var/consul-license.hclic",
   "ui": true,
   "log_level": "INFO",
   "data_dir": "/tmp/consul/server1",
@@ -73,6 +76,7 @@ EOF
 cat <<-EOF > /root/nomad/consul-server1.json
 {
   "server": true,
+  "license_path": "/var/consul-license.hclic",
   "ui": true,
   "log_level": "INFO",
   "data_dir": "/tmp/consul/server1",
@@ -109,6 +113,7 @@ EOF
 cat <<-EOF > /root/nomad/consul-client1.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1",
@@ -146,6 +151,7 @@ EOF
 cat <<-EOF > /root/nomad/consul-client2.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2",
@@ -183,6 +189,7 @@ EOF
 cat <<-EOF > /root/nomad/consul-client3.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client3",
   "node_name": "client3",

--- a/instruqt-tracks/nomad-host-volumes/config.yml
+++ b/instruqt-tracks/nomad-host-volumes/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500

--- a/instruqt-tracks/nomad-integration-with-vault/config.yml
+++ b/instruqt-tracks/nomad-integration-with-vault/config.yml
@@ -1,21 +1,21 @@
 version: "2"
 virtualmachines:
 - name: hashistack-server
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-server:8500
     VAULT_ADDR: http://127.0.0.1:8200/
   machine_type: n1-standard-1
 - name: hashistack-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-client-1:8500
     VAULT_ADDR: http://active.vault.service.consul:8200/
   machine_type: n1-standard-1
 - name: hashistack-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: hashistack-client-2:8500

--- a/instruqt-tracks/nomad-job-placement/config.yml
+++ b/instruqt-tracks/nomad-job-placement/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-2
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-3:8500

--- a/instruqt-tracks/nomad-monitoring/config.yml
+++ b/instruqt-tracks/nomad-monitoring/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-server:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: http://nomad-client-3:8500

--- a/instruqt-tracks/nomad-multi-region-federation/config.yml
+++ b/instruqt-tracks/nomad-multi-region-federation/config.yml
@@ -1,37 +1,37 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1-east
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: g1-small
 - name: nomad-client-1-east
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: g1-small
 - name: nomad-client-2-east
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: g1-small
 - name: nomad-server-1-west
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: g1-small
 - name: nomad-client-1-west
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500
   machine_type: g1-small
 - name: nomad-client-2-west
-  image: instruqt-hashicorp/hashistack-enterprise-0-9-1
+  image: instruqt-hashicorp/hashistack-enterprise-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: 127.0.0.1:8500

--- a/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-client-1-east
+++ b/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-client-1-east
@@ -38,6 +38,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-client1.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1-east",

--- a/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-client-1-west
+++ b/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-client-1-west
@@ -40,6 +40,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-client1.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1-west",

--- a/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-client-2-east
+++ b/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-client-2-east
@@ -37,6 +37,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-client2.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2-east",

--- a/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-client-2-west
+++ b/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-client-2-west
@@ -37,6 +37,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-client2.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2-west",

--- a/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-server-1-east
+++ b/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-server-1-east
@@ -28,6 +28,7 @@ name = "server1-east"
 server {
   enabled = true
   bootstrap_expect = 1
+  license_path = "/var/nomad-license.hclic"
 }
 
 # Consul configuration
@@ -40,6 +41,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-server1.json
 {
   "server": true,
+  "license_path": "/var/consul-license.hclic",
   "ui": true,
   "log_level": "INFO",
   "data_dir": "/tmp/consul/server1",

--- a/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-server-1-west
+++ b/instruqt-tracks/nomad-multi-region-federation/federation/setup-nomad-server-1-west
@@ -29,6 +29,7 @@ name = "server1-west"
 server {
   enabled = true
   bootstrap_expect = 1
+  license_path = "/var/nomad-license.hclic"
 }
 
 # Consul configuration
@@ -51,6 +52,7 @@ name = "server1-west"
 server {
   enabled = true
   bootstrap_expect = 1
+  license_path = "/var/nomad-license.hclic"
 }
 
 # Consul configuration
@@ -64,6 +66,7 @@ EOF
 cat <<-EOF > /etc/consul.d/consul-server1.json
 {
   "server": true,
+  "license_path": "/var/consul-license.hclic",
   "ui": true,
   "log_level": "INFO",
   "data_dir": "/tmp/consul/server1",
@@ -81,6 +84,7 @@ EOF
 cat <<-EOF > root/nomad/config/consul-server1-west.json
 {
   "server": true,
+  "license_path": "/var/consul-license.hclic",
   "ui": true,
   "log_level": "INFO",
   "data_dir": "/tmp/consul/server1",
@@ -108,6 +112,7 @@ name = "server1-east"
 server {
   enabled = true
   bootstrap_expect = 1
+  license_path = "/var/nomad-license.hclic"
 }
 
 # Consul configuration
@@ -120,6 +125,7 @@ EOF
 cat <<-EOF > root/nomad/config/consul-server1-east.json
 {
   "server": true,
+  "license_path": "/var/consul-license.hclic",
   "ui": true,
   "log_level": "INFO",
   "data_dir": "/tmp/consul/server1",
@@ -159,6 +165,7 @@ EOF
 cat <<-EOF > root/nomad/config/consul-client1-west.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1-west",
@@ -199,6 +206,7 @@ EOF
 cat <<-EOF > root/nomad/config/consul-client1.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client1",
   "node_name": "client1-east",
@@ -238,6 +246,7 @@ EOF
 cat <<-EOF > root/nomad/config/consul-client2.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2-west",
@@ -277,6 +286,7 @@ EOF
 cat <<-EOF > root/nomad/config/consul-client2.json
 {
   "ui": true,
+  "license_path": "/var/consul-license.hclic",
   "log_level": "INFO",
   "data_dir": "/tmp/consul/client2",
   "node_name": "client2-east",

--- a/instruqt-tracks/nomad-multi-region-federation/track.yml
+++ b/instruqt-tracks/nomad-multi-region-federation/track.yml
@@ -299,6 +299,7 @@ challenges:
     Evaluation status changed: "pending" -> "complete"
     ==> Evaluation "ffd6ba9d" finished with status "complete"
     ```
+    followed by some extra text about the monitoring of the job being stopped.
 
     Congratulations on completing the Nomad Multi-Region Federation track!
   tabs:
@@ -322,4 +323,4 @@ challenges:
     port: 4646
   difficulty: basic
   timelimit: 1200
-checksum: "7621008850869204499"
+checksum: "2448976099116780873"

--- a/instruqt-tracks/nomad-multi-server-cluster/config.yml
+++ b/instruqt-tracks/nomad-multi-server-cluster/config.yml
@@ -1,31 +1,31 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-server-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-2:8500
   machine_type: n1-standard-1
 - name: nomad-server-3
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-3:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500

--- a/instruqt-tracks/nomad-on-windows/verify-nomad-cluster-health/setup-cloud-client
+++ b/instruqt-tracks/nomad-on-windows/verify-nomad-cluster-health/setup-cloud-client
@@ -7,16 +7,16 @@ export SSHPASS=Passw0rd!
 echo "export SSHPASS=Passw0rd!" >> /root/.bashrc
 
 # Create Nomad Server
-gcloud compute instances create nomad-server-1 --image-project=instruqt-hashicorp --image=windows-hashistack-0-9-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-1
+gcloud compute instances create nomad-server-1 --image-project=instruqt-hashicorp --image=windows-hashistack-0-13-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-1
 
 # Create Nomad Client 1
-gcloud compute instances create nomad-client-1 --image-project=instruqt-hashicorp --image=windows-hashistack-0-9-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
+gcloud compute instances create nomad-client-1 --image-project=instruqt-hashicorp --image=windows-hashistack-0-13-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
 
 # Create Nomad Client 2
-gcloud compute instances create nomad-client-2 --image-project=instruqt-hashicorp --image=windows-hashistack-0-9-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
+gcloud compute instances create nomad-client-2 --image-project=instruqt-hashicorp --image=windows-hashistack-0-13-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
 
 # Create Nomad Client 3
-gcloud compute instances create nomad-client-3 --image-project=instruqt-hashicorp --image=windows-hashistack-0-9-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
+gcloud compute instances create nomad-client-3 --image-project=instruqt-hashicorp --image=windows-hashistack-0-13-1 --zone=europe-west1-b --tags=nomad --machine-type=n1-standard-2
 
 # Sleep
 sleep 60

--- a/instruqt-tracks/nomad-simple-cluster/config.yml
+++ b/instruqt-tracks/nomad-simple-cluster/config.yml
@@ -1,14 +1,14 @@
 version: "2"
 virtualmachines:
 - name: nomad-server
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   machine_type: n1-standard-1

--- a/instruqt-tracks/nomad-update-strategies/config.yml
+++ b/instruqt-tracks/nomad-update-strategies/config.yml
@@ -1,25 +1,25 @@
 version: "2"
 virtualmachines:
 - name: nomad-server-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-server-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-1
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-1:8500
   machine_type: n1-standard-1
 - name: nomad-client-2
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-2:8500
   machine_type: n1-standard-1
 - name: nomad-client-3
-  image: instruqt-hashicorp/hashistack-0-13-0
+  image: instruqt-hashicorp/hashistack-0-13-1
   shell: /bin/bash -l
   environment:
     CONSUL_HTTP_ADDR: nomad-client-3:8500


### PR DESCRIPTION
This finishes updating all of the Instruqt tracks to use Nomad 1.2.4.
The big changes are in the nomad-governance and nomad-federation tracks which use Nomad Enterprise and Consul Enterprise.  Their config files now read enterprise license files which are injected into the modified instruqt-hashicorp/hashistack-enterprise-0-13-1 GCP image.
I also built a new hashistack-0-13-1 image and updated the other Nomad Instruqt tracks to use it instead of hashistack-0-13-0 which I had updated to yesterday.